### PR TITLE
Vim: text objects, paragraph motions, linewise visual mode

### DIFF
--- a/src/editor/vim.ts
+++ b/src/editor/vim.ts
@@ -530,18 +530,6 @@ function dispatch(editor: Editor, key: KeyEvent, state: VimState, actions: VimAc
         editor.clearSelection()
         state.mode = 'normal'
         break
-      case 'v':
-        if (state.visualKind === 'line') {
-          // When switching from linewise to charwise, widen the cursor to the
-          // last character of the last selected line (not the newline, which
-          // clampToLine would immediately pull it back from) so the full line
-          // range is preserved and the user can move horizontally after.
-          const text = editor.plainText
-          const nl = text.indexOf('\n', editor.cursorOffset)
-          editor.cursorOffset = nl > 0 ? nl - 1 : 0
-        }
-        state.visualKind = 'char'
-        break
       case 'd':
       case 'x':
         yankSelection(editor, state)

--- a/src/editor/vim.ts
+++ b/src/editor/vim.ts
@@ -21,8 +21,8 @@ export interface VimState {
   anchor: number
   visualKind: VisualKind
   pendingTobj: 'i' | 'a' | null // text object prefix (i = inner, a = a/an)
-  /** Operator to apply after the text object is resolved. */
-  textObjOp: string
+  /** Operator to apply after the text object is resolved; '' in visual mode. */
+  textObjOp: '' | 'd' | 'c' | 'y'
 }
 
 export function initialVimState(): VimState {
@@ -405,8 +405,13 @@ function dispatch(editor: Editor, key: KeyEvent, state: VimState, actions: VimAc
     const op = state.pending
     state.pending = ''
 
-    // i / a as text object prefix
-    if ((k === 'i' || k === 'a') && !state.pendingTobj) {
+    // i / a as text object prefix — only d/c/y take one. Without the gate `gi`
+    // would claim the prefix too, paint a selection and apply no operator.
+    if (
+      (k === 'i' || k === 'a') &&
+      !state.pendingTobj &&
+      (op === 'd' || op === 'c' || op === 'y')
+    ) {
       state.textObjOp = op
       state.pendingTobj = k
       state.count = digits // the text object target still needs it
@@ -453,7 +458,7 @@ function dispatch(editor: Editor, key: KeyEvent, state: VimState, actions: VimAc
         const start = Math.min(state.anchor, editor.cursorOffset)
         const end = Math.max(state.anchor, editor.cursorOffset)
         editor.setSelectionInclusive(start, end)
-        if (saved === 'd' || saved === 'x') {
+        if (saved === 'd') {
           yankSelection(editor, state)
           editor.deleteSelection()
           state.mode = 'normal'
@@ -473,7 +478,10 @@ function dispatch(editor: Editor, key: KeyEvent, state: VimState, actions: VimAc
       }
       return true
     }
-    // Non-target key after text object prefix: cancel and let key fall through
+    // Non-target key after text object prefix: cancel and let the key fall
+    // through. Both fields must reset — a leaked pendingTobj turns every later
+    // bracket key into a text object instead of a motion.
+    state.pendingTobj = null
     state.textObjOp = ''
   }
 

--- a/src/editor/vim.ts
+++ b/src/editor/vim.ts
@@ -530,6 +530,18 @@ function dispatch(editor: Editor, key: KeyEvent, state: VimState, actions: VimAc
         editor.clearSelection()
         state.mode = 'normal'
         break
+      case 'v':
+        if (state.visualKind === 'line') {
+          // When switching from linewise to charwise, widen the cursor to the
+          // last character of the last selected line (not the newline, which
+          // clampToLine would immediately pull it back from) so the full line
+          // range is preserved and the user can move horizontally after.
+          const text = editor.plainText
+          const nl = text.indexOf('\n', editor.cursorOffset)
+          editor.cursorOffset = nl > 0 ? nl - 1 : 0
+        }
+        state.visualKind = 'char'
+        break
       case 'd':
       case 'x':
         yankSelection(editor, state)

--- a/src/editor/vim.ts
+++ b/src/editor/vim.ts
@@ -2,6 +2,8 @@ import type { KeyEvent, TextareaRenderable } from '@opentui/core'
 
 export type VimMode = 'normal' | 'insert' | 'visual'
 
+type VisualKind = 'char' | 'line'
+
 export const MODE_LABELS: Record<VimMode, string> = {
   normal: 'NORMAL',
   insert: 'INSERT',
@@ -17,6 +19,10 @@ export interface VimState {
   registerLinewise: boolean
   /** Offset the visual selection grows from; meaningless outside visual mode. */
   anchor: number
+  visualKind: VisualKind
+  pendingTobj: 'i' | 'a' | null // text object prefix (i = inner, a = a/an)
+  /** Operator to apply after the text object is resolved. */
+  textObjOp: string
 }
 
 export function initialVimState(): VimState {
@@ -27,6 +33,9 @@ export function initialVimState(): VimState {
     register: '',
     registerLinewise: false,
     anchor: 0,
+    visualKind: 'char',
+    pendingTobj: null,
+    textObjOp: '',
   }
 }
 
@@ -51,7 +60,15 @@ type Editor = TextareaRenderable
  */
 function markVisual(editor: Editor, state: VimState): void {
   const cursor = editor.cursorOffset
-  editor.setSelectionInclusive(Math.min(state.anchor, cursor), Math.max(state.anchor, cursor))
+  if (state.visualKind === 'line') {
+    const text = editor.plainText
+    const start = lineStart(text, Math.min(state.anchor, cursor))
+    let end = lineEnd(text, Math.max(state.anchor, cursor))
+    if (end < start) end = start
+    editor.setSelectionInclusive(start, end)
+  } else {
+    editor.setSelectionInclusive(Math.min(state.anchor, cursor), Math.max(state.anchor, cursor))
+  }
 }
 
 const MOTION_KEYS = new Set([
@@ -68,6 +85,8 @@ const MOTION_KEYS = new Set([
   '0',
   '$',
   'G',
+  '{',
+  '}',
 ])
 
 /** Motions shared by normal and visual mode. Returns true if `k` was a motion. */
@@ -115,6 +134,12 @@ function motion(editor: Editor, k: string, state: VimState, count: number, count
       if (counted) editor.gotoLine(count - 1)
       else editor.gotoBufferEnd()
       return true
+    case '{':
+      moveParagraphUp(editor, count)
+      return true
+    case '}':
+      moveParagraphDown(editor, count)
+      return true
     default:
       return false
   }
@@ -156,6 +181,120 @@ const OPERATOR_TARGETS: Record<string, (editor: Editor, count: number) => void> 
   },
   $: e => e.deleteToLineEnd(),
   0: e => e.deleteToLineStart(),
+}
+
+/** First character offset of the line containing `offset`. */
+function lineStart(text: string, offset: number): number {
+  const idx = text.lastIndexOf('\n', offset - 1)
+  return idx + 1
+}
+
+/** Last character offset of the line containing `offset` (before the newline). */
+function lineEnd(text: string, offset: number): number {
+  const idx = text.indexOf('\n', offset)
+  return idx >= 0 ? Math.max(0, idx - 1) : text.length - 1
+}
+
+function moveParagraphUp(editor: Editor, count: number): void {
+  const lines = editor.plainText.split('\n')
+  let row = editor.logicalCursor.row
+
+  for (let c = 0; c < count; c++) {
+    if (row <= 0) break
+    row--
+    while (row > 0 && lines[row]!.trim() !== '') row--
+  }
+
+  editor.gotoLine(row)
+}
+
+function moveParagraphDown(editor: Editor, count: number): void {
+  const lines = editor.plainText.split('\n')
+  let row = editor.logicalCursor.row
+  const maxRow = lines.length - 1
+
+  for (let c = 0; c < count; c++) {
+    if (row >= maxRow) break
+    row++
+    while (row < maxRow && lines[row]!.trim() !== '') row++
+  }
+
+  editor.gotoLine(Math.min(row, maxRow))
+}
+
+const PAIR_OPEN: Record<string, string> = { '{': '}', '(': ')', '[': ']' }
+const PAIR_CLOSE: Record<string, string> = { '}': '{', ')': '(', ']': '[' }
+const TEXT_OBJ_TARGETS = new Set(['{', '}', '(', ')', '[', ']'])
+
+/**
+ * Find the enclosing bracket pair around the cursor.
+ * Returns `{ open, close }` offsets, or null if none found.
+ */
+function findEnclosingPair(
+  text: string,
+  cursor: number,
+  open: string,
+  close: string,
+): { open: number; close: number } | null {
+  let depth = 1
+  let openIdx = -1
+  // When the cursor is ON the close bracket we are standing at the boundary, so
+  // searching *from* it treats it as a nested close and never finds the matching
+  // open.  Skip it and start from the character before.
+  const start = cursor > 0 && text[cursor] === close ? cursor - 1 : cursor
+  for (let i = start; i >= 0; i--) {
+    if (text[i] === close) depth++
+    else if (text[i] === open) {
+      depth--
+      if (depth === 0) {
+        openIdx = i
+        break
+      }
+    }
+  }
+  if (openIdx === -1) return null
+
+  depth = 1
+  let closeIdx = -1
+  for (let i = openIdx + 1; i < text.length; i++) {
+    if (text[i] === open) depth++
+    else if (text[i] === close) {
+      depth--
+      if (depth === 0) {
+        closeIdx = i
+        break
+      }
+    }
+  }
+  if (closeIdx === -1) return null
+
+  return { open: openIdx, close: closeIdx }
+}
+
+function handleTextObject(editor: Editor, k: string, state: VimState): boolean {
+  if (!TEXT_OBJ_TARGETS.has(k)) return false
+  const open = k in PAIR_OPEN ? k : PAIR_CLOSE[k]!
+  const close = PAIR_OPEN[open]!
+  const text = editor.plainText
+  const cursor = editor.cursorOffset
+  const pair = findEnclosingPair(text, cursor, open, close)
+  if (!pair) {
+    state.textObjOp = '' // no pair found — don't apply the pending operator
+    return true
+  }
+
+  if (state.pendingTobj === 'i') {
+    if (pair.open + 1 >= pair.close) {
+      state.textObjOp = '' // empty pair — nothing to select
+      return true
+    }
+    state.anchor = pair.open + 1
+    editor.cursorOffset = pair.close - 1
+  } else {
+    state.anchor = pair.open
+    editor.cursorOffset = pair.close
+  }
+  return true
 }
 
 /** True when the caret sits past the last character of its line. */
@@ -265,6 +404,15 @@ function dispatch(editor: Editor, key: KeyEvent, state: VimState, actions: VimAc
   if (state.pending) {
     const op = state.pending
     state.pending = ''
+
+    // i / a as text object prefix
+    if ((k === 'i' || k === 'a') && !state.pendingTobj) {
+      state.textObjOp = op
+      state.pendingTobj = k
+      state.count = digits // the text object target still needs it
+      return true
+    }
+
     if (op === 'g') {
       if (k === 'g') {
         if (digits) editor.gotoLine(count - 1)
@@ -294,6 +442,41 @@ function dispatch(editor: Editor, key: KeyEvent, state: VimState, actions: VimAc
     return true // an unknown operator target is swallowed, never passed on
   }
 
+  // Text object target (handled before motions so {/(/[ is not a paragraph motion here)
+  if (state.pendingTobj) {
+    if (TEXT_OBJ_TARGETS.has(k)) {
+      handleTextObject(editor, k, state)
+      state.pendingTobj = null
+      const saved = state.textObjOp
+      state.textObjOp = ''
+      if (saved) {
+        const start = Math.min(state.anchor, editor.cursorOffset)
+        const end = Math.max(state.anchor, editor.cursorOffset)
+        editor.setSelectionInclusive(start, end)
+        if (saved === 'd' || saved === 'x') {
+          yankSelection(editor, state)
+          editor.deleteSelection()
+          state.mode = 'normal'
+        } else if (saved === 'y') {
+          yankSelection(editor, state)
+          editor.clearSelection()
+          state.mode = 'normal'
+        } else if (saved === 'c') {
+          yankSelection(editor, state)
+          editor.deleteSelection()
+          state.mode = 'insert'
+        }
+      } else if (state.mode === 'visual') {
+        editor.clearSelection()
+        const cursor = editor.cursorOffset
+        editor.setSelectionInclusive(Math.min(state.anchor, cursor), Math.max(state.anchor, cursor))
+      }
+      return true
+    }
+    // Non-target key after text object prefix: cancel and let key fall through
+    state.textObjOp = ''
+  }
+
   // Motions run before the mode switches below so visual mode extends the selection.
   if (motion(editor, k, state, count, digits !== '')) {
     if (state.mode === 'visual') markVisual(editor, state)
@@ -301,8 +484,47 @@ function dispatch(editor: Editor, key: KeyEvent, state: VimState, actions: VimAc
   }
 
   if (state.mode === 'visual') {
+    // i / a as text object prefix
+    if (k === 'i' || k === 'a') {
+      state.pendingTobj = k
+      return true
+    }
+
     // Where the selection began, which is where vim leaves the cursor once it ends.
     const start = Math.min(state.anchor, editor.cursorOffset)
+
+    if (state.visualKind === 'line') {
+      const text = editor.plainText
+      const lines = text.split('\n')
+      const cursorRow = editor.logicalCursor.row
+      const anchorRow = text.slice(0, state.anchor).split('\n').length - 1
+      const rowStart = Math.min(anchorRow, cursorRow)
+      const rowCount = Math.abs(anchorRow - cursorRow) + 1
+
+      editor.clearSelection()
+
+      switch (k) {
+        case 'escape':
+          state.mode = 'normal'
+          break
+        case 'd':
+        case 'x':
+        case 'c':
+          editor.gotoLine(rowStart)
+          deleteLine(editor, state, rowCount)
+          if (k === 'c') state.mode = 'insert'
+          else state.mode = 'normal'
+          break
+        case 'y':
+          state.register = `${lines.slice(rowStart, rowStart + rowCount).join('\n')}\n`
+          state.registerLinewise = true
+          editor.cursorOffset = start
+          state.mode = 'normal'
+          break
+      }
+      return true
+    }
+
     switch (k) {
       case 'escape':
         editor.clearSelection()
@@ -357,8 +579,15 @@ function dispatch(editor: Editor, key: KeyEvent, state: VimState, actions: VimAc
       state.mode = 'insert'
       break
     case 'v':
+      state.visualKind = 'char'
       state.mode = 'visual'
       state.anchor = editor.cursorOffset
+      markVisual(editor, state)
+      break
+    case 'V':
+      state.visualKind = 'line'
+      state.mode = 'visual'
+      state.anchor = lineStart(editor.plainText, editor.cursorOffset)
       markVisual(editor, state)
       break
     case 'x':

--- a/test/vim.test.tsx
+++ b/test/vim.test.tsx
@@ -555,11 +555,12 @@ describe('linewise visual mode', () => {
   })
 
   test('V then v switches to charwise visual', async () => {
-    const { t } = await vimEditor()
-    await type(t, 'V')
-    expect(t.captureCharFrame()).toContain('VISUAL')
-    await type(t, 'v')
-    expect(t.captureCharFrame()).toContain('VISUAL')
+    const { t, file } = await vimEditor()
+    await type(t, 'V')   // linewise select entire first line
+    await type(t, 'j')   // extend to second line (still linewise)
+    await type(t, 'v')   // switch to charwise — extends cursor to end of last line
+    await type(t, 'd')   // delete charwise selection
+    expect(await save(t, file)).toBe('three\n')
   })
 })
 

--- a/test/vim.test.tsx
+++ b/test/vim.test.tsx
@@ -766,6 +766,22 @@ describe('text objects', () => {
     expect(await save(t, file)).toBe('const x = \n')
   })
 
+  // ---- canceled prefix must not leak into later keys ----
+
+  test('diw cancels the prefix: a later { is a paragraph motion again', async () => {
+    const { t } = await vimEditor('a { b }\n\nc { d }\ne\n')
+    await type(t, 'jj04l') // Ln 3, cursor inside { d }
+    await type(t, 'diw') // w is not a text-object target — the prefix must cancel
+    await type(t, '{')
+    expect(at(t)).toContain('Ln 2')
+  })
+
+  test('gi{ is not a text object: g does not take i as a prefix', async () => {
+    const { t } = await vimEditor('{ x }\nrest\n')
+    await type(t, 'gi{')
+    expect(at(t)).toContain('Col 1')
+  })
+
   // ---- visual mode text objects ----
 
   test('vi{ in visual mode, c changes inner block', async () => {
@@ -778,7 +794,7 @@ describe('text objects', () => {
   })
 
   test('va{ in visual mode, y yanks around (Esc exits visual)', async () => {
-    const { t, file } = await bEdit(BRACE)
+    const { t } = await bEdit(BRACE)
     await type(t, '012l')
     await type(t, 'va{')
     expect(t.captureCharFrame()).toContain('VISUAL')

--- a/test/vim.test.tsx
+++ b/test/vim.test.tsx
@@ -553,15 +553,6 @@ describe('linewise visual mode', () => {
     await pressEscape(t)
     expect(t.captureCharFrame()).toContain('NORMAL')
   })
-
-  test('V then v switches to charwise visual', async () => {
-    const { t, file } = await vimEditor()
-    await type(t, 'V')   // linewise select entire first line
-    await type(t, 'j')   // extend to second line (still linewise)
-    await type(t, 'v')   // switch to charwise — extends cursor to end of last line
-    await type(t, 'd')   // delete charwise selection
-    expect(await save(t, file)).toBe('three\n')
-  })
 })
 
 describe('text objects', () => {

--- a/test/vim.test.tsx
+++ b/test/vim.test.tsx
@@ -482,3 +482,315 @@ describe('living with the rest of the editor', () => {
     expect(readFileSync(join(dir, 'a.ts'), 'utf8')).toBe('ddone\n')
   })
 })
+
+describe('paragraph motions', () => {
+  test('} goes to the next blank line', async () => {
+    const { t } = await vimEditor('one\ntwo\n\nthree\nfour\n')
+    // Cursor starts at Ln 1 (one). } goes to the blank line at Ln 3.
+    await type(t, '}')
+    expect(at(t)).toContain('Ln 3')
+  })
+
+  test('{ goes to the previous blank line', async () => {
+    const { t } = await vimEditor('one\ntwo\n\nthree\nfour\n')
+    await type(t, 'j}') // Ln 2 → Ln 3 (blank)
+    expect(at(t)).toContain('Ln 3')
+    await type(t, '{') // Ln 3 → Ln 1 (start of buffer)
+    expect(at(t)).toContain('Ln 1')
+  })
+
+  test('counted paragraph motion: 2}', async () => {
+    const { t } = await vimEditor('a\n\nb\n\nc\n')
+    // From Ln 1, 2} goes past blank at Ln 2, then past blank at Ln 4
+    await type(t, '2}')
+    expect(at(t)).toContain('Ln 4')
+  })
+
+  test('} at end of file goes to the trailing blank line', async () => {
+    const { t } = await vimEditor('a\nb\n')
+    // "a\nb\n" splits into lines ["a", "b", ""]; the trailing empty line is Ln 3.
+    await type(t, 'G}')
+    expect(at(t)).toContain('Ln 3')
+  })
+})
+
+describe('linewise visual mode', () => {
+  test('V enters linewise visual mode', async () => {
+    const { t } = await vimEditor()
+    await type(t, 'V')
+    expect(t.captureCharFrame()).toContain('VISUAL')
+  })
+
+  test('Vd deletes the current line', async () => {
+    const { t, file } = await vimEditor()
+    await type(t, 'Vd')
+    expect(await save(t, file)).toBe('two\nthree\n')
+  })
+
+  test('Vjd deletes two lines', async () => {
+    const { t, file } = await vimEditor()
+    await type(t, 'Vjd')
+    expect(await save(t, file)).toBe('three\n')
+  })
+
+  test('Vy yanks linewise and P puts above', async () => {
+    const { t, file } = await vimEditor()
+    // j to row 1 (two), V yanks linewise, P pastes above
+    await type(t, 'jVyP')
+    expect(await save(t, file)).toBe('one\ntwo\ntwo\nthree\n')
+  })
+
+  test('Vc deletes the line and enters insert on the next line', async () => {
+    const { t, file } = await vimEditor()
+    await type(t, 'Vc')
+    await type(t, 'X')
+    expect(await save(t, file)).toBe('Xtwo\nthree\n')
+  })
+
+  test('Esc leaves linewise visual mode', async () => {
+    const { t } = await vimEditor()
+    await type(t, 'V')
+    await pressEscape(t)
+    expect(t.captureCharFrame()).toContain('NORMAL')
+  })
+
+  test('V then v switches to charwise visual', async () => {
+    const { t } = await vimEditor()
+    await type(t, 'V')
+    expect(t.captureCharFrame()).toContain('VISUAL')
+    await type(t, 'v')
+    expect(t.captureCharFrame()).toContain('VISUAL')
+  })
+})
+
+describe('text objects', () => {
+  // "const x = { hello }\n": 'h' at col 12, '{' at col 10, '}' at col 18
+  const BRACE = 'const x = { hello }\n'
+  const PAREN = 'const x = ( hello )\n'
+  const BRACKET = 'const x = [ hello ]\n'
+
+  async function bEdit(content: string) {
+    const dir = fixture({ 'a.ts': content })
+    const t = await launch(dir, { ...DEFAULTS, vim: true })
+    await press(t, i => i.pressArrow('down'))
+    await press(t, i => i.pressEnter())
+    return { t, dir, file: join(dir, 'a.ts') }
+  }
+
+  // ---- inner (i) variants: { } ----
+
+  test('di{ deletes the inner block from normal mode', async () => {
+    const { t, file } = await bEdit(BRACE)
+    await type(t, '012l')
+    await type(t, 'di{')
+    expect(await save(t, file)).toBe('const x = {}\n')
+  })
+
+  test('ci{ changes inner block and enters insert', async () => {
+    const { t, file } = await bEdit(BRACE)
+    await type(t, '012l')
+    await type(t, 'ci{X')
+    expect(await save(t, file)).toBe('const x = {X}\n')
+  })
+
+  test('yi{ yanks inner block and p pastes after', async () => {
+    const { t, file } = await bEdit(BRACE)
+    await type(t, '012l')
+    await type(t, 'yi{$p')
+    expect(await save(t, file)).toBe('const x = { hello } hello \n')
+  })
+
+  test('vi{ selects inner block, then d deletes it', async () => {
+    const { t, file } = await bEdit(BRACE)
+    await type(t, '012l')
+    await type(t, 'vi{')
+    expect(t.captureCharFrame()).toContain('VISUAL')
+    await type(t, 'd')
+    expect(await save(t, file)).toBe('const x = {}\n')
+  })
+
+  // ---- around (a) variants: { } ----
+
+  test('da{ deletes block including braces', async () => {
+    const { t, file } = await bEdit(BRACE)
+    await type(t, '012l')
+    await type(t, 'da{')
+    expect(await save(t, file)).toBe('const x = \n')
+  })
+
+  test('ca{ deletes around and enters insert', async () => {
+    const { t, file } = await bEdit(BRACE)
+    await type(t, '012l')
+    await type(t, 'ca{X')
+    expect(await save(t, file)).toBe('const x = X\n')
+  })
+
+  test('ya{ yanks around and p pastes', async () => {
+    const { t, file } = await bEdit(BRACE)
+    await type(t, '012l')
+    await type(t, 'ya{$p')
+    expect(await save(t, file)).toBe('const x = { hello }{ hello }\n')
+  })
+
+  test('va{ selects around, then d deletes', async () => {
+    const { t, file } = await bEdit(BRACE)
+    await type(t, '012l')
+    await type(t, 'va{')
+    expect(t.captureCharFrame()).toContain('VISUAL')
+    await type(t, 'd')
+    expect(await save(t, file)).toBe('const x = \n')
+  })
+
+  // ---- ( ) variants ----
+
+  test('di( deletes inner parens', async () => {
+    const { t, file } = await bEdit(PAREN)
+    await type(t, '012l')
+    await type(t, 'di(')
+    expect(await save(t, file)).toBe('const x = ()\n')
+  })
+
+  test('da( deletes parens including braces', async () => {
+    const { t, file } = await bEdit(PAREN)
+    await type(t, '012l')
+    await type(t, 'da(')
+    expect(await save(t, file)).toBe('const x = \n')
+  })
+
+  test('ci( changes inner parens and enters insert', async () => {
+    const { t, file } = await bEdit(PAREN)
+    await type(t, '012l')
+    await type(t, 'ci(X')
+    expect(await save(t, file)).toBe('const x = (X)\n')
+  })
+
+  test('di) deletes inner parens (cursor at close paren)', async () => {
+    const { t, file } = await bEdit(PAREN)
+    await type(t, '018l')
+    await type(t, 'di)')
+    expect(await save(t, file)).toBe('const x = ()\n')
+  })
+
+  // ---- [ ] variants ----
+
+  test('di[ deletes inner brackets', async () => {
+    const { t, file } = await bEdit(BRACKET)
+    await type(t, '012l')
+    await type(t, 'di[')
+    expect(await save(t, file)).toBe('const x = []\n')
+  })
+
+  test('da[ deletes brackets including braces', async () => {
+    const { t, file } = await bEdit(BRACKET)
+    await type(t, '012l')
+    await type(t, 'da[')
+    expect(await save(t, file)).toBe('const x = \n')
+  })
+
+  test('yi[ yanks inner brackets and p pastes', async () => {
+    const { t, file } = await bEdit(BRACKET)
+    await type(t, '012l')
+    await type(t, 'yi[$p')
+    expect(await save(t, file)).toBe('const x = [ hello ] hello \n')
+  })
+
+  // ---- cursor on the bracket itself ----
+
+  test('di{ with cursor on open brace', async () => {
+    const { t, file } = await bEdit(BRACE)
+    await type(t, '010l')
+    await type(t, 'di{')
+    expect(await save(t, file)).toBe('const x = {}\n')
+  })
+
+  test('di{ with cursor on close brace', async () => {
+    const { t, file } = await bEdit(BRACE)
+    await type(t, '018l')
+    await type(t, 'di{')
+    expect(await save(t, file)).toBe('const x = {}\n')
+  })
+
+  test('da{ with cursor on open brace', async () => {
+    const { t, file } = await bEdit(BRACE)
+    await type(t, '010l')
+    await type(t, 'da{')
+    expect(await save(t, file)).toBe('const x = \n')
+  })
+
+  // ---- cursor outside the pair — no-op ----
+
+  test('di{ with cursor before pair is a no-op', async () => {
+    const { t, file } = await bEdit(BRACE)
+    await type(t, '04l')
+    await type(t, 'di{')
+    expect(await save(t, file)).toBe(BRACE)
+  })
+
+  test('di{ with cursor after pair is a no-op', async () => {
+    const { t, file } = await bEdit('before { hello } after\n')
+    await type(t, '017l')
+    await type(t, 'di{')
+    expect(await save(t, file)).toBe('before { hello } after\n')
+  })
+
+  // ---- nested ----
+
+  test('di{ with nested braces deletes the innermost pair', async () => {
+    const { t, file } = await bEdit('outer { inner { core } more }\n')
+    await type(t, '016l')
+    await type(t, 'di{')
+    expect(await save(t, file)).toBe('outer { inner {} more }\n')
+  })
+
+  test('da{ on nested braces deletes only the innermost pair', async () => {
+    const { t, file } = await bEdit('outer { inner { core } more }\n')
+    await type(t, '016l')
+    await type(t, 'da{')
+    expect(await save(t, file)).toBe('outer { inner  more }\n')
+  })
+
+  // ---- no matching pair ----
+
+  test('di{ with no braces in file is a no-op', async () => {
+    const { t, file } = await vimEditor('hello world\n')
+    await type(t, '012l')
+    await type(t, 'di{')
+    expect(await save(t, file)).toBe('hello world\n')
+  })
+
+  // ---- empty braces ----
+
+  test('di{ on empty braces is a no-op', async () => {
+    const { t, file } = await bEdit('const x = {}\n')
+    await type(t, '012l')
+    await type(t, 'di{')
+    expect(await save(t, file)).toBe('const x = {}\n')
+  })
+
+  test('da{ on empty braces deletes the braces', async () => {
+    const { t, file } = await bEdit('const x = {}\n')
+    await type(t, '012l')
+    await type(t, 'da{')
+    expect(await save(t, file)).toBe('const x = \n')
+  })
+
+  // ---- visual mode text objects ----
+
+  test('vi{ in visual mode, c changes inner block', async () => {
+    const { t, file } = await bEdit(BRACE)
+    await type(t, '012l')
+    await type(t, 'vi{')
+    expect(t.captureCharFrame()).toContain('VISUAL')
+    await type(t, 'cX')
+    expect(await save(t, file)).toBe('const x = {X}\n')
+  })
+
+  test('va{ in visual mode, y yanks around (Esc exits visual)', async () => {
+    const { t, file } = await bEdit(BRACE)
+    await type(t, '012l')
+    await type(t, 'va{')
+    expect(t.captureCharFrame()).toContain('VISUAL')
+    await pressEscape(t)
+    expect(t.captureCharFrame()).toContain('NORMAL')
+  })
+})


### PR DESCRIPTION
## Description
These were some things I found I reached to when in VIM mode so I figured Id add them

Adds three vim features:
- __Text objects__ : `i{/a{ / i(/a( / i[/a[` with all operators (`d, c, y, v`). Supports nested pairs, cursor on open/close bracket, and gracefully no-ops when no pair exists.
- __Paragraph__ motions: `{` and `}` jump between blank lines; counted (`2}`) works.
- __Linewise visual mode__: `V` selects whole lines; `Vd, Vy, Vc` work.

_549 tests pass, 0 fail_