### PR TITLE
fix(editor): draw one indent guide per tab

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -43,7 +43,11 @@ export interface Config {
   theme: ThemeName
   /** Modal editing (normal / insert / visual). */
   vim: boolean
-  /** Columns per indent level: indent guides and literal tabs both use it. */
+  /**
+   * Columns per indent level for space indentation — the Tab key and the guides.
+   * A literal tab is two columns whatever this says: OpenTUI's renderer fixes that
+   * width and exposes no setting for it.
+   */
   tabSize: number
   /**
    * Columns the file tree occupies, or `'auto'` for a share of the terminal —

--- a/src/languages/highlight.ts
+++ b/src/languages/highlight.ts
@@ -132,8 +132,17 @@ function indentGuides(content: string, tabSize: number): RawHighlight[] {
   let offset = 0
   for (const line of content.split('\n')) {
     const indent = line.length - line.trimStart().length
-    for (let column = 0; column < indent; column += tabSize) {
-      guides.push([offset + column, offset + column + 1, INDENT_GUIDE])
+    let spaces = 0
+    for (let column = 0; column < indent; column++) {
+      // A tab is an indent level by itself and OpenTUI tints its first cell as it
+      // renders (see `tabIndicator`). Marking it here too would widen the guide to
+      // the whole tab and make tab files look unlike space files.
+      if (line[column] === '\t') {
+        spaces = 0
+        continue
+      }
+      if (spaces % tabSize === 0) guides.push([offset + column, offset + column + 1, INDENT_GUIDE])
+      spaces++
     }
     offset += line.length + 1
   }

--- a/src/ui/EditorPane.tsx
+++ b/src/ui/EditorPane.tsx
@@ -958,7 +958,13 @@ export function EditorPane(props: EditorPaneProps) {
               // dragging the caret along, so unwrapped long lines have no way to be
               // read that does not move the cursor.
               wrapMode="word"
-              tabIndicator={props.tabSize}
+              // OpenTUI takes a glyph, not a width: the number it accepts is a code
+              // point, so passing a tab size painted control characters into the first
+              // cell of every tab. A terminal drops those, leaving whatever the cell
+              // held before — stale text that changes as the file scrolls.
+              // A filled block in the guide color is the only way to match the space
+              // guides, which are a background tint: the indicator sets a foreground.
+              tabIndicator="█"
               tabIndicatorColor={ui.indentGuide}
               flexGrow={1}
               paddingLeft={1}

--- a/test/indent.test.tsx
+++ b/test/indent.test.tsx
@@ -30,6 +30,15 @@ test('guides mark every indent stop at the configured width', async () => {
   expect(four.length).toBeLessThan(two.length)
 })
 
+test('a tab indent is tinted by the renderer alone', async () => {
+  // The tab already carries a guide in its first cell, so a highlight over it
+  // would tint the whole tab and make tab files look unlike space files.
+  const tabbed = 'function f() {\n\tif (x) {\n\t\treturn 1\n\t}\n}\n'
+  const segs = await allSegments(tabbed, 'typescript', 2)
+  const guide = getSyntaxStyle().getStyleId('indent.guide')
+  expect(segs.filter(s => s.styleId === guide)).toEqual([])
+})
+
 test('tab size is configurable and shown in the palette', async () => {
   const t = await launch(fixture({ 'a.ts': NESTED }), { ...DEFAULTS, tabSize: 4 })
   await press(t, i => i.pressKey('p', { ctrl: true }))
@@ -37,6 +46,24 @@ test('tab size is configurable and shown in the palette', async () => {
   const frame = t.captureCharFrame()
   expect(frame).toContain('2 spaces')
   expect(frame).toContain('* 4 spaces') // marked as active
+})
+
+test('tab indents keep drawing guides after the view scrolls', async () => {
+  // Tabs are painted by OpenTUI, not the highlighter: it writes the indicator
+  // glyph into the first cell of the tab and spaces after it. A code point it
+  // cannot print leaves those cells untouched, so the previous frame shows
+  // through and the file looks different at every scroll position.
+  const filler = Array.from({ length: 40 }, (_, i) => `\tconst x${i} = ${i}`).join('\n')
+  const content = `${filler}\n\t\t<marker/>\n${filler}\n`
+  const dir = fixture({ 'a.tsx': content })
+  const t = await launch(dir, {}, {}, { openFile: `${dir}/a.tsx` })
+
+  for (let i = 0; i < 45; i++) await press(t, input => input.pressArrow('down'))
+
+  const frame = t.captureCharFrame()
+  expect(frame).toContain('█ █ <marker/>')
+  const control = [...frame].filter(ch => ch !== '\n' && ch.codePointAt(0)! < 0x20)
+  expect(control).toEqual([])
 })
 
 test('indent guides are visible in every theme', () => {


### PR DESCRIPTION
Tab-indented files showed stale text that changed at every scroll position, and their indent guides never matched a space-indented file's.

One root cause: `tabIndicator` takes a glyph, not a width. OpenTUI reads the value as a code point and paints it into the first cell of the tab, so `tabSize` wrote **U+0002** there. A terminal drops a control character, so the cell kept whatever the previous frame left in it.

```diff
-  tabIndicator={props.tabSize}
+  tabIndicator="█"
   tabIndicatorColor={ui.indentGuide}
```

Take two lines indented with three tabs, and scroll to them from elsewhere in the file. Each tab is two columns, so six columns sit between the line number and the code — that is the guide column.

Before, those columns hold whatever the previous frame drew in them:

```
 17 t t l <p class="none">EMPTY</p>
 21 . . @ <li class="row">{r.label as string}</li>
    └────┘ six columns of leftovers: "t", "l", ".", "@"
```

After, each tab draws one guide:

```
 17 █ █ █ <p class="none">EMPTY</p>
 21 █ █ █ <li class="row">{r.label as string}</li>
    └────┘ one tinted cell per indent level
```

A block, not a bar: `tabIndicatorColor` sets a foreground, and the space guides are a background tint, so only a filled glyph matches them.

`indentGuides` also measured the indent in characters and stepped by `tabSize`, tinting the leading tabs a second time — a solid two-column block at the first level, a thin bar deeper in. It now skips tabs and leaves them to the renderer, so tabs and spaces both mark a stop with one tinted cell.

**Known limit.** A literal tab stays two columns wide whatever `tabSize` says. `TextBuffer.setTabWidth` exists in OpenTUI but no `<textarea>` can reach it, so this needs an upstream change; the `tabSize` doc comment records it.

**Tests.** A scroll regression that fails on `main` with `\^B` in the captured frame, and a unit test asserting a tab-indented file produces no `indent.guide` spans. 514 pass, 0 fail.

