### PR TITLE
feat(languages): highlight tsrx

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,7 @@ dependency rule, and recipes for the extension points:
 
 | Want to add a… | Edit |
 | --- | --- |
-| language | `src/languages/grammars.ts` + a query in `src/languages/queries/`, then `src/languages/index.ts` |
+| language | `src/languages/grammars.ts` + a query in `src/languages/queries/`, then `src/languages/index.ts`; an extension OpenTUI does not resolve also needs a line in `filetypeForPath` |
 | theme | new file in `src/themes/` + register in `src/themes/index.ts` |
 | setting | `src/core/config.ts` (`Config`, `DEFAULTS`, `parse`) |
 | command | `src/app/commands.ts` + bind it in `src/app/actions.ts`; the implementation goes in the controller that owns the state (`workspace.ts`, `fileOps.ts`, `git.ts`, …) |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -98,7 +98,11 @@ nature, and threading twenty props would say less.
 
 Grammars OpenTUI already bundles (javascript, typescript, markdown, zig) only need
 `bundled: true` — no wasm or query. Parser registration and highlighting both read from
-this one table.
+this one table. A dialect close enough to an existing language can reuse its grammar
+outright: `javascriptreact` and `tsrx` are both `...GRAMMARS.tsx`.
+
+OpenTUI resolves the extension, so a filetype it has never heard of also needs a line in
+`filetypeForPath` (`src/languages/highlight.ts`), beside the `bun.lock` and `.env` cases.
 
 The status bar shows the `id`, which is fine for almost all of them. Add a `label` only
 where OpenTUI's filetype name is not what a person would call the file — `typescriptreact`
@@ -113,6 +117,16 @@ When no grammar works — tree-sitter-yaml, for one, needs an external scanner O
 worker cannot link — declare `patterns` instead: a list of `{ group, re }` painted in
 order, later entries winning the characters they overlap. Good enough for line-oriented
 config formats, and it needs no wasm.
+
+`patterns` beside a grammar means something else: an overlay for a dialect the grammar
+cannot parse. `.tsrx` is tsx plus Octane's `@if`/`@for`/`@{` directives, which land in
+tree-sitter `ERROR` regions — a query cannot reach inside one, so the tokens are regex-
+matched instead. `outsideProse` then drops any match a comment or string capture already
+covers, and *only* those: elsewhere the overlay has to win, because the grammar
+mis-attributes these tokens rather than missing them (tsx reads `@catch` as a call and
+captures `catch` as `function`). Ordering is load-bearing in the other direction too —
+patterns without a grammar must never reach tree-sitter, which is what keeps a yaml file
+from hanging the query engine.
 
 ### Add a theme
 

--- a/src/languages/highlight.ts
+++ b/src/languages/highlight.ts
@@ -64,6 +64,7 @@ export function filetypeForPath(path: string): string | undefined {
   const name = path.slice(Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\')) + 1)
   if (BY_NAME[name]) return BY_NAME[name]
   if (DOTENV.test(name)) return 'dotenv'
+  if (name.endsWith('.tsrx')) return 'tsrx'
   return pathToFiletype(path) ?? undefined
 }
 
@@ -150,6 +151,31 @@ function highlightWithPatterns(content: string, patterns: NonNullable<Language['
   return out
 }
 
+/**
+ * Overlay matches that a comment or string capture already covers. A regex has no
+ * context, so the literal `@for` in prose is indistinguishable from the directive.
+ *
+ * Only those two, and deliberately: everywhere else the overlay must win, because
+ * the grammar mis-attributes these tokens rather than missing them — tsx reads
+ * `@catch` as a call and captures `catch` as `function`.
+ *
+ * The mask is what keeps this linear. Testing each match against every capture is
+ * O(matches x captures), and cost 100ms on a 6 000-line file — on every reparse,
+ * so on every keystroke.
+ */
+function outsideProse(
+  content: string,
+  overlay: RawHighlight[],
+  claimed: ReadonlyArray<readonly [number, number, string, ...unknown[]]>,
+): RawHighlight[] {
+  if (overlay.length === 0) return overlay
+  const prose = new Uint8Array(content.length)
+  for (const [start, end, group] of claimed) {
+    if (group.startsWith('comment') || group.startsWith('string')) prose.fill(1, start, end)
+  }
+  return overlay.filter(([start, end]) => prose.subarray(start, end).every(c => c === 0))
+}
+
 /** Answered instead of segments when `isStale` says the text moved on. */
 export const STALE = Symbol('stale')
 
@@ -195,19 +221,24 @@ export async function computeHighlights(
   isStale?: () => boolean,
 ): Promise<Highlighted | typeof STALE> {
   const guides = indentGuides(content, tabSize)
-  const patterns = filetype ? languageFor(filetype)?.patterns : undefined
-  if (patterns) {
-    return prepare(content, [...highlightWithPatterns(content, patterns), ...guides])
+  const lang = filetype ? languageFor(filetype) : undefined
+  const overlay = lang?.patterns ? highlightWithPatterns(content, lang.patterns) : []
+  // Patterns without a grammar mean no usable grammar exists, and asking for one
+  // anyway can hang the query engine (tree-sitter-yaml). Only a language that
+  // declares both wants its patterns layered over a parse.
+  if (lang?.patterns && !lang.wasm && !lang.bundled) {
+    return prepare(content, [...overlay, ...guides])
   }
 
   const client = filetype ? await ensureClient() : null
-  if (!client) return prepare(content, guides)
+  if (!client) return prepare(content, [...overlay, ...guides])
   try {
     const res = await client.highlightOnce(content, filetype!)
     if (isStale?.()) return STALE
-    return prepare(content, [...(res.highlights ?? []), ...guides])
+    const hl = res.highlights ?? []
+    return prepare(content, [...hl, ...outsideProse(content, overlay, hl), ...guides])
   } catch {
-    return prepare(content, guides)
+    return prepare(content, [...overlay, ...guides])
   }
 }
 

--- a/src/languages/index.ts
+++ b/src/languages/index.ts
@@ -54,10 +54,13 @@ export const LANGUAGES: Language[] = [
     ...GRAMMARS.tsx,
     // The `@` heads and `key` are the only tsrx tokens the tsx grammar cannot
     // parse; everything inside `@{ … }` is ordinary tsx and highlights normally.
+    // `key` needs the lookahead: the clause is always `key <expr>)` closing a
+    // `@for` header, while `; key` alone also matches ordinary statements —
+    // `run(); key.press()` would paint a plain identifier.
     patterns: [
       {
         group: 'keyword.directive',
-        re: /@(?:if|else|for|empty|switch|case|default|try|pending|catch)\b|@(?=\{)|(?<=;[ \t]*)key\b/g,
+        re: /@(?:if|else|for|empty|switch|case|default|try|pending|catch)\b|@(?=\{)|(?<=;[ \t]*)key\b(?=[ \t]+[\w$.[\]]+[ \t]*\))/g,
       },
     ],
   },

--- a/src/languages/index.ts
+++ b/src/languages/index.ts
@@ -32,8 +32,10 @@ export interface Language {
   /** Path to the highlight query, when we vendor the grammar ourselves. */
   query?: string
   /**
-   * Regex highlighting, for formats with no usable grammar. Patterns paint in
-   * order, so later entries win the characters they overlap.
+   * Regex highlighting. Alone, it is the whole answer for a format with no usable
+   * grammar. Beside a grammar, it is an overlay for a dialect the grammar cannot
+   * parse — see `outsideProse` in ./highlight.ts for what it may override.
+   * Patterns paint in order, so later entries win the characters they overlap.
    */
   patterns?: { group: string; re: RegExp }[]
 }
@@ -47,6 +49,18 @@ export const LANGUAGES: Language[] = [
   { id: 'html', ...GRAMMARS.html },
   { id: 'typescriptreact', label: 'tsx', ...GRAMMARS.tsx },
   { id: 'javascriptreact', label: 'jsx', ...GRAMMARS.tsx },
+  {
+    id: 'tsrx',
+    ...GRAMMARS.tsx,
+    // The `@` heads and `key` are the only tsrx tokens the tsx grammar cannot
+    // parse; everything inside `@{ … }` is ordinary tsx and highlights normally.
+    patterns: [
+      {
+        group: 'keyword.directive',
+        re: /@(?:if|else|for|empty|switch|case|default|try|pending|catch)\b|@(?=\{)|(?<=;[ \t]*)key\b/g,
+      },
+    ],
+  },
   { id: 'vue', ...GRAMMARS.vue },
   { id: 'css', ...GRAMMARS.css },
   { id: 'scss', ...GRAMMARS.css },
@@ -156,6 +170,7 @@ const LINE_COMMENTS: Record<string, string> = {
   typescript: '//',
   javascriptreact: '//',
   typescriptreact: '//',
+  tsrx: '//',
   zig: '//',
   scss: '//',
   less: '//',

--- a/test/languages.test.ts
+++ b/test/languages.test.ts
@@ -10,6 +10,7 @@ const SAMPLES: Record<string, string> = {
   rust: 'fn main() {\n    let x: i32 = 1; // c\n}\n',
   go: 'package main\n// c\nfunc main() { return }\n',
   typescriptreact: '// c\nconst A = () => <div className="a">{1}</div>\n',
+  tsrx: '// c\nexport function A() @{\n\t@if (ok) {\n\t\t<p>{x as string}</p>\n\t}\n}\n',
   vue: '<template>\n  <!-- c -->\n  <div class="a">x</div>\n</template>\n',
   css: '.a { color: #fff; }\n/* c */\n',
   scss: '/* c */\n$brand: #f00;\n.a { color: $brand; &:hover { top: 1px } }\n',

--- a/test/tsrx.test.ts
+++ b/test/tsrx.test.ts
@@ -131,4 +131,14 @@ export function App(props: { rows: Row[]; step: string }) @{
 
     expect(group('keyword')).not.toContain('key')
   })
+
+  test('key in an ordinary statement on one line stays plain', async () => {
+    // `; key` is exactly how the clause sits in a `@for` header, so the pattern
+    // needs the `key <expr>)` shape to tell the two apart.
+    const group = await painted(
+      `export function A() @{\n\trun(); key.press(); key = 2;\n\t@for (const r of rows; key r.id) {\n\t\t<li>{r.id}</li>\n\t}\n}\n`,
+    )
+
+    expect(group('keyword').filter(t => t === 'key')).toEqual(['key'])
+  })
 })

--- a/test/tsrx.test.ts
+++ b/test/tsrx.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from 'bun:test'
+
+import { filetypeForPath, getSyntaxStyle } from '../src/languages/highlight'
+import { allSegments } from './syntax'
+
+/** What each group got painted on, so a pattern change shows up as text. */
+async function painted(source: string) {
+  const segments = await allSegments(source, 'tsrx')
+  const lines = source.split('\n')
+  const style = getSyntaxStyle()
+  const byGroup = new Map<number, string[]>()
+  for (const segment of segments) {
+    const text = lines[segment.line]?.slice(segment.start, segment.end) ?? ''
+    if (!text.trim()) continue
+    byGroup.set(segment.styleId, [...(byGroup.get(segment.styleId) ?? []), text.trim()])
+  }
+  return (group: string) => byGroup.get(style.getStyleId(group)!) ?? []
+}
+
+describe('recognising tsrx files', () => {
+  test('by extension, wherever the file sits', () => {
+    expect(filetypeForPath('App.tsrx')).toBe('tsrx')
+    expect(filetypeForPath('src/routes/App.lynx.tsrx')).toBe('tsrx')
+  })
+
+  test('without stealing files that merely contain the letters', () => {
+    expect(filetypeForPath('tsrx.d.ts')).toBe('typescript')
+    expect(filetypeForPath('notatsrx')).toBeUndefined()
+  })
+})
+
+describe('painting tsrx files', () => {
+  // Octane indents with tabs, as every file in its repo does.
+  const SAMPLE = `import { use } from 'octane';
+
+// Prose naming @for and @try and @{ stays prose.
+export function App(props: { rows: Row[]; step: string }) @{
+\tconst total = props.rows.length;
+
+\t<main class="feed">
+\t\t@if (total > 0) {
+\t\t\t<p>{'have' as string}</p>
+\t\t} @else {
+\t\t\t<p>none</p>
+\t\t}
+\t\t@for (const r of props.rows; key r.id) {
+\t\t\t<li>{r.label as string}</li>
+\t\t} @empty {
+\t\t\t<li>blank</li>
+\t\t}
+\t\t@switch (props.step) {
+\t\t\t@case 'one': {
+\t\t\t\t<span>1</span>
+\t\t\t}
+\t\t\t@default: {
+\t\t\t\t<span>x</span>
+\t\t\t}
+\t\t}
+\t\t@try {
+\t\t\t<output>{use(thing) as string}</output>
+\t\t} @pending {
+\t\t\t<p>wait</p>
+\t\t} @catch (err, reset) {
+\t\t\t<button onClick={reset}>x</button>
+\t\t}
+\t</main>
+}
+`
+
+  // A grammar that names a node it does not have matches nothing, silently. The
+  // whole point of the tsx grammar here is that everything inside `@{ … }` keeps
+  // highlighting, so assert the ordinary tsx tokens as well as the directives.
+  test('the body inside @{ … } highlights as ordinary tsx', async () => {
+    const group = await painted(SAMPLE)
+
+    expect(group('keyword')).toContain('import')
+    expect(group('keyword')).toContain('const')
+    expect(group('string')).toContain(`'octane'`)
+    expect(group('tag')).toContain('main')
+    expect(group('attribute')).toContain('class')
+    expect(group('type')).toContain('string')
+  })
+
+  for (const directive of [
+    '@if',
+    '@else',
+    '@for',
+    '@empty',
+    '@switch',
+    '@case',
+    '@default',
+    '@try',
+    '@pending',
+    '@catch',
+  ]) {
+    test(`${directive} reads as a keyword`, async () => {
+      const group = await painted(SAMPLE)
+      expect(group('keyword')).toContain(directive)
+    })
+  }
+
+  test('the @ of the body marker, and key, are keywords too', async () => {
+    const group = await painted(SAMPLE)
+    // `{` belongs to the grammar as a bracket; only the `@` is ours.
+    expect(group('keyword')).toContain('@')
+    expect(group('keyword')).toContain('key')
+  })
+
+  test('a directive named in a comment stays a comment', async () => {
+    const group = await painted(SAMPLE)
+    // The overlay is regex-driven and cannot tell prose from code by itself. Left
+    // to specificity alone, `keyword.directive` outranks `comment` and lights up
+    // every mention of a directive in a doc comment. Asserting the line survives
+    // *whole* is what catches that: lighting `@for` inside it splits the comment
+    // into fragments, and the same directive really does appear in the code below,
+    // so no assertion about the keyword group alone can tell the two apart.
+    expect(group('comment')).toContain('// Prose naming @for and @try and @{ stays prose.')
+  })
+
+  test('a directive named in a string stays a string', async () => {
+    const group = await painted(`const help = '@if needs a block';\n`)
+
+    expect(group('keyword')).not.toContain('@if')
+    expect(group('string')).toContain(`'@if needs a block'`)
+  })
+
+  test('key is only the @for clause, not any identifier after a semicolon', async () => {
+    const group = await painted(
+      `export function A() @{\n\tlet x = 1;\n\n\tkey = 2;\n\t<p>x</p>\n}\n`,
+    )
+
+    expect(group('keyword')).not.toContain('key')
+  })
+})


### PR DESCRIPTION
Syntax highlighting for `.tsrx` — tsx plus Octane's directives:

https://github.com/octanejs/octane

```tsx
@for (const r of props.rows; key r.id) {
	<li class="row">{r.label as string}</li>
} @empty {
	<li class="blank">no rows</li>
}
```

The tsx grammar parses the file until it meets a directive; that directive and everything after it lands in a tree-sitter `ERROR` region, and a query cannot reach inside one. So `tsrx` reuses the tsx grammar and declares `patterns` beside it — a regex overlay for the tokens the grammar cannot see.

That gives `patterns` a second meaning. It used to mark a format with *no* usable grammar, and those must never reach tree-sitter — that is what keeps a yaml file from hanging the query engine. The guard now tests for both:

```diff
-  if (lang?.patterns) {
+  if (lang?.patterns && !lang.wasm && !lang.bundled) {
     return prepare(content, [...overlay, ...guides])
   }
```

Layered over a parse, the overlay is filtered by `outsideProse`: any match a comment or string capture already covers is dropped, so `@for` in prose stays prose. Only those two groups — everywhere else the overlay has to win, because the grammar *mis-attributes* these tokens rather than missing them (tsx reads `@catch` as a call and captures `catch` as `function`). The byte mask keeps it linear; comparing every match against every capture cost ~100ms per keystroke on a 6000-line file.

`filetypeForPath` also names `.tsrx` explicitly, since OpenTUI resolves languages by extension and has never heard of it.

**Tests.** `test/tsrx.test.ts` covers recognition (including `tsrx.d.ts`, which must stay typescript) and painting; `test/languages.test.ts` gains a tsrx sample. 530 pass, 0 fail.

