### PR TITLE
feat: VS Code keybindings preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,12 @@ status bar with the branch, unsaved state and cursor position.
 In the tree: `a` new file, `A` new folder, `r` rename, `d` delete, `x` cut, `c` copy,
 `p` paste here, `Shift+↑`/`↓` select several rows, `[` / `]` resize the sidebar.
 
-Two things worth knowing: `Ctrl+C` copies when text is selected and quits when nothing is,
-so it never throws away unsaved work. And there are no `Ctrl+Shift` shortcuts — most
+Three things worth knowing: `Ctrl+C` copies when text is selected and quits when nothing
+is, so it never throws away unsaved work. There are no `Ctrl+Shift` shortcuts — most
 terminals cannot tell them apart from plain `Ctrl` — so a second modifier is always
-`Ctrl+Opt`.
+`Ctrl+Opt`. And if your fingers are set in VS Code's ways, `"keybindings": "vscode"`
+gives `Ctrl+P` to the file picker and moves the palette to `F1` (and `Ctrl+Shift+P`,
+in terminals that can send it).
 
 ### The Opt / Alt key
 
@@ -160,6 +162,7 @@ A bad value falls back to the default instead of breaking startup.
 | `theme` | `"dark"` | `dark`, `light`, `ayu-dark`, `ayu-mirage`, `ayu-light`, `catppuccin-mocha`, `catppuccin-macchiato`, `catppuccin-frappe`, `catppuccin-latte`, `dracula`, `everforest-dark`, `everforest-light`, `gruvbox`, `gruvbox-light`, `kanagawa-wave`, `kanagawa-dragon`, `kanagawa-lotus`, `nord`, `one-dark`, `rose-pine`, `rose-pine-moon`, `rose-pine-dawn`, `solarized-dark`, `solarized-light`, `tokyo-night`, `vesper` |
 | `tabSize` | `2` | 1–16 |
 | `vim` | `false` | normal / insert / visual modes, `hjkl w b 0 $ gg G`, counts, `i a o`, `x dd dw cw`, `v` + `d y c`, `yy p P`, `u` / `Ctrl+R` |
+| `keybindings` | `"default"` | `"vscode"` gives `Ctrl+P` to the file picker and moves the palette to `F1` / `Ctrl+Shift+P` |
 | `sidebarWidth` | `"auto"` | a quarter of the window, or pin 15–80 columns |
 | `trimOnSave` | `false` | on save: strip trailing spaces and end the file with one newline |
 | `autoSaveOnBlur` | `false` | save unsaved tabs when switching tabs or when the terminal window loses focus |

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -280,6 +280,7 @@ export function App(props: {
             edit={editor.edit()}
             lineOp={editor.lineOp()}
             vim={config.vim}
+            vscodeKeys={config.keybindings === 'vscode'}
             tabSize={config.tabSize}
             gitLines={git.gitLines()}
             notice={workspace.notice()}
@@ -328,6 +329,7 @@ export function App(props: {
         behind={git.upstream()?.behind ?? 0}
         changed={git.gitStatus().size}
         focus={panes.focus()}
+        vscodeKeys={config.keybindings === 'vscode'}
         busy={status.busy()}
       />
       <OverlayStack ctx={ctx} commands={commands} />

--- a/src/app/Overlays.tsx
+++ b/src/app/Overlays.tsx
@@ -248,10 +248,10 @@ export function OverlayStack(props: { ctx: AppContext; commands: Accessor<Comman
         )}
       </Show>
       <Show when={overlays.peek()}>
-        <KeyPeek pane={panes.focus()} />
+        <KeyPeek pane={panes.focus()} vscodeKeys={settings.config.keybindings === 'vscode'} />
       </Show>
       <Show when={overlays.help()}>
-        <HelpOverlay />
+        <HelpOverlay vscodeKeys={settings.config.keybindings === 'vscode'} />
       </Show>
     </>
   )

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -96,6 +96,7 @@ export function createCommands(ctx: AppContext) {
     toggleFocus: () => (panes.focus() === 'tree' ? panes.setFocus('editor') : panes.focusTree()),
     toggleSidebar: panes.toggleSidebar,
     setVim: settings.applyVim,
+    setKeybindings: settings.applyKeybindings,
     setTabSize: settings.applyTabSize,
     setTheme: settings.applyTheme,
     lineOp: editor.requestLineOp,
@@ -167,6 +168,7 @@ export function createCommands(ctx: AppContext) {
   return createMemo<Command[]>(() =>
     buildCommands(actions, {
       vimEnabled: config.vim,
+      vscodeKeys: config.keybindings === 'vscode',
       activeTheme: config.theme,
       tabSize: config.tabSize,
       trimOnSave: config.trimOnSave,

--- a/src/app/commands.ts
+++ b/src/app/commands.ts
@@ -48,6 +48,7 @@ export interface CommandActions {
   toggleFocus: () => void
   toggleSidebar: () => void
   setVim: (enabled: boolean) => void
+  setKeybindings: (keybindings: 'default' | 'vscode') => void
   setTabSize: (size: number) => void
   setTheme: (name: ThemeName) => void
   lineOp: (op: 'comment' | 'up' | 'down' | 'duplicate') => void
@@ -68,6 +69,7 @@ export interface CommandActions {
 
 export interface CommandContext {
   vimEnabled: boolean
+  vscodeKeys: boolean
   activeTheme: ThemeName
   tabSize: number
   trimOnSave: boolean
@@ -81,7 +83,12 @@ const check = (on: boolean) => (on ? '* ' : '  ')
 
 export function buildCommands(actions: CommandActions, ctx: CommandContext): Command[] {
   return [
-    { id: 'open', label: 'Open file…', hint: 'Ctrl+O', run: actions.openFile },
+    {
+      id: 'open',
+      label: 'Open file…',
+      hint: ctx.vscodeKeys ? 'Ctrl+P / Ctrl+O' : 'Ctrl+O',
+      run: actions.openFile,
+    },
     { id: 'save', label: 'Save file', hint: 'Ctrl+S', run: actions.save },
     { id: 'goto', label: 'Go to line…', hint: 'Ctrl+G', run: actions.gotoLine },
     { id: 'undo', label: 'Undo', hint: 'Ctrl+Z', run: actions.undo },
@@ -217,6 +224,16 @@ export function buildCommands(actions: CommandActions, ctx: CommandContext): Com
           id: 'editor.vimOff',
           label: `${check(!ctx.vimEnabled)}Vim mode off`,
           run: () => actions.setVim(false),
+        },
+        {
+          id: 'editor.vscodeKeysOn',
+          label: `${check(ctx.vscodeKeys)}VS Code keys on — Ctrl+P opens a file, F1 the palette`,
+          run: () => actions.setKeybindings('vscode'),
+        },
+        {
+          id: 'editor.vscodeKeysOff',
+          label: `${check(!ctx.vscodeKeys)}VS Code keys off`,
+          run: () => actions.setKeybindings('default'),
         },
         {
           id: 'editor.tabSize',

--- a/src/app/keyboard.ts
+++ b/src/app/keyboard.ts
@@ -48,7 +48,15 @@ export function installKeyboard(ctx: AppContext) {
     // renderer's own selection covers mouse drags only. Either way it
     // routes through `quit()`, so a dirty buffer still gets its prompt.
     if (key.ctrl && k === 'c' && panes.focus() !== 'editor') return claim(prompts.quit)
-    if (key.ctrl && k === 'p') return claim(() => overlays.setPalette(true))
+    // With VS Code keys, Ctrl+P opens a file — as it does there — and the palette
+    // moves to Ctrl+Shift+P, a chord only kitty-protocol terminals can send as
+    // distinct bytes. F1, VS Code's other palette key, works everywhere, so it
+    // opens the palette under either preset.
+    if (k === 'f1') return claim(() => overlays.setPalette(true))
+    if (key.ctrl && k === 'p') {
+      const openFile = config.keybindings === 'vscode' && !chord(key)
+      return claim(() => (openFile ? overlays.setPicker('files') : overlays.setPalette(true)))
+    }
     if (key.ctrl && k === 'o') return claim(() => overlays.setPicker('files'))
     if (key.ctrl && chord(key) && k === 't') return claim(workspace.reopenTab)
     // Ctrl+E is line-end in every terminal; keep the tab family on the arrows.

--- a/src/app/settings.ts
+++ b/src/app/settings.ts
@@ -44,6 +44,15 @@ export function createSettings(deps: {
     status.say(`Vim mode ${enabled ? 'on' : 'off'}`)
   }
 
+  const applyKeybindings = (keybindings: Config['keybindings']) => {
+    patchConfig({ keybindings })
+    status.say(
+      keybindings === 'vscode'
+        ? 'VS Code keys — Ctrl+P opens a file, F1 the palette'
+        : 'VS Code keys off',
+    )
+  }
+
   const toggleTrim = () => {
     patchConfig({ trimOnSave: !config.trimOnSave })
     status.say(`Trim on save ${config.trimOnSave ? 'on' : 'off'}`)
@@ -93,6 +102,7 @@ export function createSettings(deps: {
     applyTheme,
     applyTabSize,
     applyVim,
+    applyKeybindings,
     toggleTrim,
     toggleAutoSave,
     toggleDiffView,

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -44,6 +44,11 @@ export interface Config {
   /** Modal editing (normal / insert / visual). */
   vim: boolean
   /**
+   * Keymap preset. `'vscode'` gives Ctrl+P to the file picker, as VS Code does,
+   * and moves the command palette to F1 / Ctrl+Shift+P.
+   */
+  keybindings: 'default' | 'vscode'
+  /**
    * Columns per indent level for space indentation — the Tab key and the guides.
    * A literal tab is two columns whatever this says: OpenTUI's renderer fixes that
    * width and exposes no setting for it.
@@ -68,6 +73,7 @@ export interface Config {
 export const DEFAULTS: Config = {
   theme: 'dark',
   vim: false,
+  keybindings: 'default',
   tabSize: 2,
   sidebarWidth: 'auto',
   skipUpdate: '',
@@ -81,6 +87,7 @@ function parse(raw: unknown): Config {
   return {
     theme: isThemeName(obj.theme) ? obj.theme : DEFAULTS.theme,
     vim: typeof obj.vim === 'boolean' ? obj.vim : DEFAULTS.vim,
+    keybindings: obj.keybindings === 'vscode' ? 'vscode' : DEFAULTS.keybindings,
     tabSize:
       typeof obj.tabSize === 'number' && obj.tabSize >= 1 && obj.tabSize <= 16
         ? Math.floor(obj.tabSize)

--- a/src/ui/EditorPane.tsx
+++ b/src/ui/EditorPane.tsx
@@ -37,6 +37,8 @@ export interface EditorPaneProps {
   /** A line edit asked for from the palette; bumped `key` re-applies. */
   lineOp: { op: 'comment' | 'up' | 'down' | 'duplicate'; key: number } | null
   vim: boolean
+  /** VS Code keymap preset — the empty-state hints must name the right palette key. */
+  vscodeKeys: boolean
   tabSize: number
   /** True while a modal owns the keyboard; the editor must ignore all keys. */
   blocked: boolean
@@ -894,7 +896,11 @@ export function EditorPane(props: EditorPaneProps) {
             <text fg={ui.dim} bg={ui.bg} content="druk" attributes={TextAttributes.BOLD} />
             <text fg={ui.faint} bg={ui.bg} content="" />
             <text fg={ui.faint} bg={ui.bg} content="Enter   open file from the tree" />
-            <text fg={ui.faint} bg={ui.bg} content="Ctrl+P  commands" />
+            <text
+              fg={ui.faint}
+              bg={ui.bg}
+              content={props.vscodeKeys ? 'F1      commands' : 'Ctrl+P  commands'}
+            />
             <text fg={ui.faint} bg={ui.bg} content="Ctrl+F  find" />
           </box>
         }

--- a/src/ui/HelpOverlay.tsx
+++ b/src/ui/HelpOverlay.tsx
@@ -1,10 +1,10 @@
 import { TextAttributes } from '@opentui/core'
 import type { KeyEvent } from '@opentui/core'
 import { useKeyboard, useTerminalDimensions } from '@opentui/solid'
-import { createSignal, For, Match, Switch } from 'solid-js'
+import { createMemo, createSignal, For, Match, Switch } from 'solid-js'
 
 import { ui } from '../themes'
-import { SECTIONS } from './keys'
+import { sectionsFor } from './keys'
 import { modalWidth, PAD } from './modal'
 import { Overlay } from './Overlay'
 
@@ -13,26 +13,27 @@ type Line =
   | { kind: 'key'; key: string; label: string }
   | { kind: 'gap' }
 
-/** The sections flattened to display lines, so one window can scroll them all. */
-const LINES: Line[] = SECTIONS.flatMap((section, index) => [
-  ...(index > 0 ? [{ kind: 'gap' } as const] : []),
-  { kind: 'header', text: section.title } as const,
-  ...section.rows.map(([key, label]) => ({ kind: 'key', key, label }) as const),
-])
-
-export function HelpOverlay() {
+export function HelpOverlay(props: { vscodeKeys: boolean }) {
+  /** The sections flattened to display lines, so one window can scroll them all. */
+  const lines = createMemo<Line[]>(() =>
+    sectionsFor(props.vscodeKeys).flatMap((section, index) => [
+      ...(index > 0 ? [{ kind: 'gap' } as const] : []),
+      { kind: 'header', text: section.title } as const,
+      ...section.rows.map(([key, label]) => ({ kind: 'key', key, label }) as const),
+    ]),
+  )
   const dimensions = useTerminalDimensions()
   const width = () => modalWidth(dimensions().width, 0.52, 58, 84)
   // The full table outgrows a 24-row terminal, so only a window is drawn.
-  const visible = () => Math.max(3, Math.min(LINES.length, dimensions().height - 7))
+  const visible = () => Math.max(3, Math.min(lines().length, dimensions().height - 7))
   const [top, setTop] = createSignal(0)
-  const overflowing = () => visible() < LINES.length
+  const overflowing = () => visible() < lines().length
 
   useKeyboard((key: KeyEvent) => {
     const step = key.name === 'up' ? -1 : key.name === 'down' ? 1 : 0
     if (step === 0) return
     key.preventDefault()
-    setTop(at => Math.max(0, Math.min(LINES.length - visible(), at + step)))
+    setTop(at => Math.max(0, Math.min(lines().length - visible(), at + step)))
   })
 
   return (
@@ -51,7 +52,7 @@ export function HelpOverlay() {
         paddingTop={1}
         paddingBottom={1}
       >
-        <For each={LINES.slice(top(), top() + visible())}>
+        <For each={lines().slice(top(), top() + visible())}>
           {line => (
             <Switch>
               <Match when={line.kind === 'header' && line}>

--- a/src/ui/KeyPeek.tsx
+++ b/src/ui/KeyPeek.tsx
@@ -17,11 +17,11 @@ const clip = (label: string, width: number) =>
  * the status bar. Opened by a key and closed by the next one, so it reads as
  * "hold to see" without needing key-release events no classic terminal sends.
  */
-export function KeyPeek(props: { pane: 'tree' | 'editor' }) {
+export function KeyPeek(props: { pane: 'tree' | 'editor'; vscodeKeys: boolean }) {
   const dimensions = useTerminalDimensions()
 
   const layout = createMemo(() => {
-    const entries = keysFor(props.pane)
+    const entries = keysFor(props.pane, props.vscodeKeys)
     const inner = dimensions().width - 2 - PAD * 2
     const keyWidth = Math.max(...entries.map(entry => entry.key.length))
     const wanted = keyWidth + 1 + Math.max(...entries.map(entry => entry.label.length)) + GAP

--- a/src/ui/StatusBar.tsx
+++ b/src/ui/StatusBar.tsx
@@ -23,6 +23,8 @@ export interface StatusBarProps {
   /** Files differing from HEAD in the working tree. */
   changed: number
   focus: 'tree' | 'editor'
+  /** VS Code keymap preset — the advertised palette key differs. */
+  vscodeKeys: boolean
   /** A long file operation in flight; replaces the message while it runs. */
   busy: { label: string; done: number; total: number } | null
 }
@@ -122,7 +124,7 @@ export function StatusBar(props: StatusBarProps) {
     const room = budget()
     const shown: Array<readonly [string, string]> = []
     let used = 0
-    for (const hint of hintsFor(props.focus)) {
+    for (const hint of hintsFor(props.focus, props.vscodeKeys)) {
       const width = hint[0].length + 1 + hint[1].length + SEPARATOR.length
       if (used + width > room) break
       shown.push(hint)

--- a/src/ui/keys.ts
+++ b/src/ui/keys.ts
@@ -4,6 +4,10 @@
  * anywhere else is a key one of them will not know about. The real handlers
  * live in App and EditorPane; `test/hotkeys.test.tsx` sweeps the two together.
  *
+ * The table is a function of the `keybindings` preset: with VS Code keys,
+ * Ctrl+P opens a file and the palette answers to F1 / Ctrl+Shift+P, so the
+ * first rows have to say so or every surface built from here would lie.
+ *
  * Entries sit grouped by `section`, which is what the help overlay renders
  * under headings — a new entry belongs beside its section mates, not at the end.
  */
@@ -25,105 +29,132 @@ export interface KeyInfo {
   hint?: { pane: Pane | 'all'; label: string; rank: number; key?: string }
 }
 
-export const KEYS: KeyInfo[] = [
-  {
-    key: 'Ctrl+P',
-    label: 'Command palette (+ themes)',
-    section: 'General',
-    where: 'all',
-    hint: { pane: 'all', label: 'commands', rank: 0 },
-  },
-  {
-    key: 'Ctrl+K',
-    label: 'Peek at every key for this pane',
-    section: 'General',
-    where: 'all',
-    hint: { pane: 'all', label: 'keys', rank: 1 },
-  },
-  { key: 'Ctrl+O', label: 'Open file (fuzzy)', section: 'General', where: 'all' },
-  { key: 'Ctrl+G', label: 'Go to line', section: 'General', where: 'all' },
-  { key: 'Ctrl+Q', label: 'Quit', section: 'General', where: 'all' },
-  { key: 'Mouse', label: 'Click tabs, tree rows, editor', section: 'General', where: 'help' },
+export function keyTable(vscodeKeys: boolean): KeyInfo[] {
+  return [
+    vscodeKeys
+      ? {
+          key: 'F1 / Ctrl+Shift+P',
+          label: 'Command palette (+ themes)',
+          section: 'General',
+          where: 'all',
+          hint: { pane: 'all', label: 'commands', rank: 0, key: 'F1' },
+        }
+      : {
+          key: 'Ctrl+P / F1',
+          label: 'Command palette (+ themes)',
+          section: 'General',
+          where: 'all',
+          hint: { pane: 'all', label: 'commands', rank: 0, key: 'Ctrl+P' },
+        },
+    {
+      key: 'Ctrl+K',
+      label: 'Peek at every key for this pane',
+      section: 'General',
+      where: 'all',
+      hint: { pane: 'all', label: 'keys', rank: 1 },
+    },
+    {
+      key: vscodeKeys ? 'Ctrl+P / Ctrl+O' : 'Ctrl+O',
+      label: 'Open file (fuzzy)',
+      section: 'General',
+      where: 'all',
+    },
+    { key: 'Ctrl+G', label: 'Go to line', section: 'General', where: 'all' },
+    { key: 'Ctrl+Q', label: 'Quit', section: 'General', where: 'all' },
+    { key: 'Mouse', label: 'Click tabs, tree rows, editor', section: 'General', where: 'help' },
 
-  { key: 'Ctrl+S', label: 'Save file', section: 'Editing', where: 'editor' },
-  { key: 'Ctrl+Z / Ctrl+Y', label: 'Undo / redo', section: 'Editing', where: 'editor' },
-  { key: 'Ctrl+A', label: 'Select all', section: 'Editing', where: 'editor' },
-  { key: 'Ctrl+C', label: 'Copy selection — quits if none', section: 'Editing', where: 'all' },
-  { key: 'Ctrl+X / Ctrl+V', label: 'Cut / paste', section: 'Editing', where: 'editor' },
-  { key: 'Ctrl+/ · Ctrl+L', label: 'Toggle comment', section: 'Editing', where: 'editor' },
-  { key: `${ALT}+↑ / ↓`, label: 'Move line or selection', section: 'Editing', where: 'editor' },
-  {
-    key: `${ALT}+Shift+↑ / ↓`,
-    label: 'Duplicate line or selection',
-    section: 'Editing',
-    where: 'editor',
-  },
-  { key: 'Shift+Tab', label: 'Outdent', section: 'Editing', where: 'editor' },
+    { key: 'Ctrl+S', label: 'Save file', section: 'Editing', where: 'editor' },
+    { key: 'Ctrl+Z / Ctrl+Y', label: 'Undo / redo', section: 'Editing', where: 'editor' },
+    { key: 'Ctrl+A', label: 'Select all', section: 'Editing', where: 'editor' },
+    { key: 'Ctrl+C', label: 'Copy selection — quits if none', section: 'Editing', where: 'all' },
+    { key: 'Ctrl+X / Ctrl+V', label: 'Cut / paste', section: 'Editing', where: 'editor' },
+    { key: 'Ctrl+/ · Ctrl+L', label: 'Toggle comment', section: 'Editing', where: 'editor' },
+    { key: `${ALT}+↑ / ↓`, label: 'Move line or selection', section: 'Editing', where: 'editor' },
+    {
+      key: `${ALT}+Shift+↑ / ↓`,
+      label: 'Duplicate line or selection',
+      section: 'Editing',
+      where: 'editor',
+    },
+    { key: 'Shift+Tab', label: 'Outdent', section: 'Editing', where: 'editor' },
 
-  {
-    key: 'Ctrl+F',
-    label: 'Find in file (Tab to replace)',
-    section: 'Search & replace',
-    where: 'editor',
-  },
-  { key: 'Ctrl+R', label: 'Find in project', section: 'Search & replace', where: 'all' },
-  {
-    key: 'Enter / Ctrl+A',
-    label: 'Replace this match / all (in replace)',
-    section: 'Search & replace',
-    where: 'help',
-  },
-  {
-    key: `Ctrl+C / W / R`,
-    label: 'Case / whole word / regex (in search)',
-    section: 'Search & replace',
-    where: 'help',
-  },
+    {
+      key: 'Ctrl+F',
+      label: 'Find in file (Tab to replace)',
+      section: 'Search & replace',
+      where: 'editor',
+    },
+    { key: 'Ctrl+R', label: 'Find in project', section: 'Search & replace', where: 'all' },
+    {
+      key: 'Enter / Ctrl+A',
+      label: 'Replace this match / all (in replace)',
+      section: 'Search & replace',
+      where: 'help',
+    },
+    {
+      key: `Ctrl+C / W / R`,
+      label: 'Case / whole word / regex (in search)',
+      section: 'Search & replace',
+      where: 'help',
+    },
 
-  { key: 'Ctrl+N', label: 'New file', section: 'Files & tabs', where: 'all' },
-  { key: `Ctrl+${ALT}+N`, label: 'New folder', section: 'Files & tabs', where: 'all' },
-  { key: 'Ctrl+W', label: 'Close tab', section: 'Files & tabs', where: 'all' },
-  { key: `Ctrl+${ALT}+T`, label: 'Reopen closed tab', section: 'Files & tabs', where: 'all' },
-  { key: 'Ctrl+T', label: 'Switch to open tab', section: 'Files & tabs', where: 'all' },
-  { key: `Ctrl+${ALT}+← / →`, label: 'Previous / next tab', section: 'Files & tabs', where: 'all' },
+    { key: 'Ctrl+N', label: 'New file', section: 'Files & tabs', where: 'all' },
+    { key: `Ctrl+${ALT}+N`, label: 'New folder', section: 'Files & tabs', where: 'all' },
+    { key: 'Ctrl+W', label: 'Close tab', section: 'Files & tabs', where: 'all' },
+    { key: `Ctrl+${ALT}+T`, label: 'Reopen closed tab', section: 'Files & tabs', where: 'all' },
+    { key: 'Ctrl+T', label: 'Switch to open tab', section: 'Files & tabs', where: 'all' },
+    {
+      key: `Ctrl+${ALT}+← / →`,
+      label: 'Previous / next tab',
+      section: 'Files & tabs',
+      where: 'all',
+    },
 
-  { key: 'Enter', label: 'Open file / toggle folder', section: 'File tree', where: 'tree' },
-  { key: '↑↓', label: 'Move in tree / popup', section: 'File tree', where: 'tree' },
-  { key: 'Shift+↑ / ↓', label: 'Select a range (in tree)', section: 'File tree', where: 'tree' },
-  { key: '→ / ←', label: 'Expand / collapse folder', section: 'File tree', where: 'tree' },
-  {
-    key: 'h j k l',
-    label: 'Move / collapse / expand (vim mode)',
-    section: 'File tree',
-    where: 'tree',
-  },
-  { key: 'a / A', label: 'New file / folder (in tree)', section: 'File tree', where: 'tree' },
-  { key: 'r / d', label: 'Rename / delete (in tree)', section: 'File tree', where: 'tree' },
-  {
-    key: 'x / c / p',
-    label: 'Cut / copy / paste here (in tree)',
-    section: 'File tree',
-    where: 'tree',
-  },
-  { key: '[ / ]', label: 'Narrow / widen sidebar (in tree)', section: 'File tree', where: 'tree' },
+    { key: 'Enter', label: 'Open file / toggle folder', section: 'File tree', where: 'tree' },
+    { key: '↑↓', label: 'Move in tree / popup', section: 'File tree', where: 'tree' },
+    { key: 'Shift+↑ / ↓', label: 'Select a range (in tree)', section: 'File tree', where: 'tree' },
+    { key: '→ / ←', label: 'Expand / collapse folder', section: 'File tree', where: 'tree' },
+    {
+      key: 'h j k l',
+      label: 'Move / collapse / expand (vim mode)',
+      section: 'File tree',
+      where: 'tree',
+    },
+    { key: 'a / A', label: 'New file / folder (in tree)', section: 'File tree', where: 'tree' },
+    { key: 'r / d', label: 'Rename / delete (in tree)', section: 'File tree', where: 'tree' },
+    {
+      key: 'x / c / p',
+      label: 'Cut / copy / paste here (in tree)',
+      section: 'File tree',
+      where: 'tree',
+    },
+    {
+      key: '[ / ]',
+      label: 'Narrow / widen sidebar (in tree)',
+      section: 'File tree',
+      where: 'tree',
+    },
 
-  {
-    key: 'Ctrl+B',
-    label: 'Show / hide sidebar',
-    section: 'View',
-    where: 'all',
-  },
-  {
-    key: 'Tab',
-    label: 'Tree → editor · indent in editor',
-    section: 'View',
-    where: 'all',
-  },
-  { key: 'Esc', label: 'Editor → tree', section: 'View', where: 'editor' },
-]
+    {
+      key: 'Ctrl+B',
+      label: 'Show / hide sidebar',
+      section: 'View',
+      where: 'all',
+    },
+    {
+      key: 'Tab',
+      label: 'Tree → editor · indent in editor',
+      section: 'View',
+      where: 'all',
+    },
+    { key: 'Esc', label: 'Editor → tree', section: 'View', where: 'editor' },
+  ]
+}
 
 /** The help table: every row, key and long label. */
-export const ROWS: [string, string][] = KEYS.map(info => [info.key, info.label])
+export function rowsFor(vscodeKeys: boolean): [string, string][] {
+  return keyTable(vscodeKeys).map(info => [info.key, info.label])
+}
 
 export interface HelpSection {
   title: string
@@ -131,20 +162,26 @@ export interface HelpSection {
 }
 
 /** The table split at its section boundaries, for the help overlay's headings. */
-export const SECTIONS: HelpSection[] = KEYS.reduce<HelpSection[]>((out, info) => {
-  if (out.at(-1)?.title !== info.section) out.push({ title: info.section, rows: [] })
-  out.at(-1)!.rows.push([info.key, info.label])
-  return out
-}, [])
+export function sectionsFor(vscodeKeys: boolean): HelpSection[] {
+  return keyTable(vscodeKeys).reduce<HelpSection[]>((out, info) => {
+    if (out.at(-1)?.title !== info.section) out.push({ title: info.section, rows: [] })
+    out.at(-1)!.rows.push([info.key, info.label])
+    return out
+  }, [])
+}
 
 /** Footer hints for `pane`, most useful first. */
-export function hintsFor(pane: Pane): ReadonlyArray<readonly [string, string]> {
-  return KEYS.filter(info => info.hint && (info.hint.pane === pane || info.hint.pane === 'all'))
+export function hintsFor(
+  pane: Pane,
+  vscodeKeys: boolean,
+): ReadonlyArray<readonly [string, string]> {
+  return keyTable(vscodeKeys)
+    .filter(info => info.hint && (info.hint.pane === pane || info.hint.pane === 'all'))
     .toSorted((a, b) => a.hint!.rank - b.hint!.rank)
     .map(info => [info.hint!.key ?? info.key, info.hint!.label] as const)
 }
 
 /** Everything alive in `pane`, for the peek strip. */
-export function keysFor(pane: Pane): KeyInfo[] {
-  return KEYS.filter(info => info.where === pane || info.where === 'all')
+export function keysFor(pane: Pane, vscodeKeys: boolean): KeyInfo[] {
+  return keyTable(vscodeKeys).filter(info => info.where === pane || info.where === 'all')
 }

--- a/test/hotkeys.test.tsx
+++ b/test/hotkeys.test.tsx
@@ -2,8 +2,8 @@ import { expect, test } from 'bun:test'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 
-import { ROWS } from '../src/ui/keys'
-import { fixture, launch, press, pressEscape, settle } from './helpers'
+import { rowsFor } from '../src/ui/keys'
+import { fixture, launch, press, pressEscape, runCommand, settle } from './helpers'
 import type { Harness } from './helpers'
 
 const ESC = String.fromCharCode(27)
@@ -147,12 +147,44 @@ test('every advertised hotkey does something', async () => {
   expect(dead).toEqual([])
 }, 120000)
 
-test('the help table does not list one key twice with different meanings', () => {
-  const keys = ROWS.map(([key]) => key)
-  expect(new Set(keys).size).toBe(keys.length)
+test('VS Code keys: Ctrl+P opens a file, F1 the palette, chorded Ctrl+P still the palette', async () => {
+  let t = await launch(fixture(PROJECT), { keybindings: 'vscode' })
+  await press(t, i => i.pressKey('p', { ctrl: true }))
+  expect(frame(t)).toContain('Open file')
 
-  // Ctrl+C both copies and quits; the row has to say so, or it reads as a bug
-  // when the editor exits. This is the row that misled once already.
-  const copyRow = ROWS.find(([key]) => key.includes('Ctrl+C'))!
-  expect(copyRow[1].toLowerCase()).toContain('quit')
+  t = await launch(fixture(PROJECT), { keybindings: 'vscode' })
+  await press(t, i => void i.pressKeys([`${ESC}OP`]))
+  expect(frame(t)).toContain('Commands')
+
+  // Ctrl+Opt+P spells the chord the way Terminal.app does for Ctrl+Shift+P's
+  // family: an ESC prefix ahead of the Ctrl+P byte (0x10).
+  t = await launch(fixture(PROJECT), { keybindings: 'vscode' })
+  await press(t, i => void i.pressKeys([`${ESC}${String.fromCharCode(16)}`]))
+  expect(frame(t)).toContain('Commands')
+})
+
+test('F1 opens the palette under the default keys too', async () => {
+  const t = await tree()
+  await press(t, i => void i.pressKeys([`${ESC}OP`]))
+  expect(frame(t)).toContain('Commands')
+})
+
+test('turning VS Code keys on from the palette reroutes Ctrl+P immediately', async () => {
+  const t = await tree()
+  await runCommand(t, 'VS Code keys on')
+  await press(t, i => i.pressKey('p', { ctrl: true }))
+  expect(frame(t)).toContain('Open file')
+})
+
+test('the help table does not list one key twice with different meanings', () => {
+  for (const vscodeKeys of [false, true]) {
+    const rows = rowsFor(vscodeKeys)
+    const keys = rows.map(([key]) => key)
+    expect(new Set(keys).size).toBe(keys.length)
+
+    // Ctrl+C both copies and quits; the row has to say so, or it reads as a bug
+    // when the editor exits. This is the row that misled once already.
+    const copyRow = rows.find(([key]) => key.includes('Ctrl+C'))!
+    expect(copyRow[1].toLowerCase()).toContain('quit')
+  }
 })

--- a/test/ui.test.tsx
+++ b/test/ui.test.tsx
@@ -12,6 +12,7 @@ function rowOf(label: string): number {
   const actions = new Proxy({} as CommandActions, { get: () => () => {} })
   const tree = buildCommands(actions, {
     vimEnabled: false,
+    vscodeKeys: false,
     activeTheme: 'dark',
     tabSize: 2,
     trimOnSave: false,

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -72,6 +72,7 @@ describe('registries', () => {
     })
     const tree = buildCommands(actions, {
       vimEnabled: false,
+      vscodeKeys: false,
       activeTheme: 'dark',
       tabSize: 2,
       trimOnSave: false,


### PR DESCRIPTION
Adds a `keybindings` setting (`"default"` | `"vscode"`), toggled from the palette (*VS Code keys on/off*) or in `config.json`.

With VS Code keys:

- `Ctrl+P` opens the file picker, as it does in VS Code.
- The palette moves to `Ctrl+Shift+P` — and since only kitty-protocol terminals can send that chord as distinct bytes, `F1` (VS Code's other palette key) carries it everywhere else. `F1` opens the palette under either preset, so the muscle memory works even without opting in.
- Everything that already matched VS Code (`Ctrl+F`, `Ctrl+S`, `Ctrl+W`, `Ctrl+B`, `Ctrl+G`, `Ctrl+N`, `Ctrl+/`, `Alt+↑/↓`, `Ctrl+Shift+F/T` via the existing chord handling) is untouched.

Since the status-bar hints, help overlay, `Ctrl+K` peek, empty-editor screen and palette hints all advertise `Ctrl+P`, `src/ui/keys.ts` became a function of the preset and each surface takes a `vscodeKeys` prop — so none of them lies about where the palette lives, whichever preset is active.

Tests: the hotkey sweep gained cases for `Ctrl+P` → file picker, `F1` → palette (both presets), the `Ctrl+Opt+P` chord spelling, and toggling the preset from the palette taking effect immediately; the help-table duplicate check now runs against both presets.

Verified with `check-types`, `lint`, `format` and the affected test files (hotkeys/ui/unit, 21 pass); the full suite ran once single-process at 584/585, the one failure being a load-related flake in `delete-selection.test.tsx` that passes 8/8 solo on this branch.