### PR TITLE
feat: source-control sidebar panel (VS Code's git view)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,10 @@ installer — and run as a CLI.
 
 Features: file tree with bulk file operations, preview/pinned tabs, tree-sitter syntax
 highlighting, search (current file and project-wide), command palette, themes, vim mode,
-git marks in tree/gutter/status bar plus palette commands for commit/undo/stash/push/
-fetch/pull, a diff view (inline or side-by-side, one file or every change), file watching
-with conflict prompts, per-project session restore, and a startup update check.
+git marks in tree/gutter/status bar plus a source-control panel in the sidebar and
+palette commands for commit/undo/stash/push/fetch/pull, a diff view (inline or
+side-by-side, one file or every change), file watching with conflict prompts,
+per-project session restore, and a startup update check.
 
 ## Runtime and tooling
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -29,7 +29,7 @@ scripts/
     fileOps.ts       move/copy/delete batches and the x/c/p clipboard
     git.ts           git signals, the serialised mutation runner, refresh effects
     prompts.ts       prompt/confirm state machine (and quit, which may prompt)
-    panes.ts         focus + sidebar visibility
+    panes.ts         focus, sidebar visibility, and which view it shows (tree / git)
     editor.ts        one-shot signal channels into EditorPane (goto, undo, edits…)
     settings.ts      config store + the actions that patch and persist it
     status.ts        status-bar message + the one busy/progress slot
@@ -67,7 +67,7 @@ scripts/
     window.ts        visual rows -> logical lines, for the highlight window
     typing.ts        auto-closing pairs and indentation on Enter
   ui/                presentational components, no app state
-    EditorPane, FileTree, Tabs, StatusBar, CommandPalette, FilePicker,
+    EditorPane, FileTree, GitPanel, Tabs, StatusBar, CommandPalette, FilePicker,
     SearchPanel, DiffView, UpdateBanner, Overlay, TextInput, PromptModal,
     ConfirmModal, ChoiceModal, HelpOverlay
 ```

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ status bar with the branch, unsaved state and cursor position.
 | `Opt+Shift+↑` / `↓` | Duplicate line or selection |
 | `Ctrl+Opt+T` | Reopen closed tab |
 | `Ctrl+Opt+←` / `→` | Previous / next tab |
+| `Ctrl+Opt+G` | Source control panel (commit / push) |
 
 In the tree: `a` new file, `A` new folder, `r` rename, `d` delete, `x` cut, `c` copy,
 `p` paste here, `Shift+↑`/`↓` select several rows, `[` / `]` resize the sidebar.
@@ -143,12 +144,17 @@ gone.
 
 ## Git
 
-Read-only, on purpose: druk shows what git says and never changes it. Changed lines are
-marked in the gutter and again beside the scrollbar, where the whole file's changes are
-visible at once — a mark there is somewhere to scroll to. Files in the tree carry `M` `A`
-`U` `D` marks, and the status bar shows the branch and how far it is from upstream —
-`⎇ main ↑2 ↓1 ~3` is two commits to push, one to pull, three changed files. Work you do in
-another terminal shows up without a restart.
+Changed lines are marked in the gutter and again beside the scrollbar, where the whole
+file's changes are visible at once — a mark there is somewhere to scroll to. Files in the
+tree carry `M` `A` `U` `D` marks, and the status bar shows the branch and how far it is
+from upstream — `⎇ main ↑2 ↓1 ~3` is two commits to push, one to pull, three changed
+files. Work you do in another terminal shows up without a restart.
+
+`Ctrl+Opt+G` swaps the sidebar for a small source-control panel, as in VS Code: the
+changed files under the branch name. `Enter` shows a file's diff, `c` commits (pick the
+files, type the message), `p` pushes, and `Esc` puts the file tree back. The same
+commands — with diff, pull, fetch, stash and undo-commit beside them — live in the
+palette under *Git*.
 
 ## Settings
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -6,6 +6,7 @@ import { createSignal, For, onCleanup, onMount, Show } from 'solid-js'
 
 import type { Config } from '../core/config'
 import { watchTree } from '../core/fs'
+import { inRepository } from '../core/git'
 import { checkForUpdate } from '../core/update'
 import { languageLabel } from '../languages'
 import { filetypeForPath } from '../languages/highlight'
@@ -14,6 +15,7 @@ import { DiffView } from '../ui/DiffView'
 import type { DiffFile } from '../ui/DiffView'
 import { EditorPane } from '../ui/EditorPane'
 import { FileTree } from '../ui/FileTree'
+import { GitPanel } from '../ui/GitPanel'
 import { StatusBar } from '../ui/StatusBar'
 import { Tabs } from '../ui/Tabs'
 import { createCommands } from './actions'
@@ -109,8 +111,8 @@ export function App(props: {
   }
 
   wireGitEffects({ rootDir, git, tree, editor, workspace })
-  const commands = createCommands(ctx)
-  installKeyboard(ctx)
+  const { commands, actions } = createCommands(ctx)
+  installKeyboard(ctx, actions)
 
   const { config } = settings
   const { say } = status
@@ -219,25 +221,47 @@ export function App(props: {
         onMouseUp={() => setResizing(false)}
       >
         <Show when={panes.sidebar()}>
-          <FileTree
-            rootName={basename(rootDir) || rootDir}
-            nodes={tree.nodes()}
-            selectedPath={tree.selectedPath()}
-            expanded={tree.expanded()}
-            focused={panes.focus() === 'tree'}
-            width={settings.treeWidth()}
-            gitStatus={git.gitStatus()}
-            cutPaths={fileOps.cut()}
-            markedPaths={tree.marked()}
-            onActivate={node => {
-              // Landing in a file is how the diff page closes — the tree stays
-              // interactive while it is up, like any other editor page.
-              overlays.setDiff(null)
-              workspace.activateNode(node)
-            }}
-            onPin={node => workspace.pinTab(node.path)}
-            onFocus={() => panes.setFocus('tree')}
-          />
+          <Show
+            when={panes.view() === 'git'}
+            fallback={
+              <FileTree
+                rootName={basename(rootDir) || rootDir}
+                nodes={tree.nodes()}
+                selectedPath={tree.selectedPath()}
+                expanded={tree.expanded()}
+                focused={panes.focus() === 'tree'}
+                width={settings.treeWidth()}
+                gitStatus={git.gitStatus()}
+                cutPaths={fileOps.cut()}
+                markedPaths={tree.marked()}
+                onActivate={node => {
+                  // Landing in a file is how the diff page closes — the tree stays
+                  // interactive while it is up, like any other editor page.
+                  overlays.setDiff(null)
+                  workspace.activateNode(node)
+                }}
+                onPin={node => workspace.pinTab(node.path)}
+                onFocus={() => panes.setFocus('tree')}
+              />
+            }
+          >
+            <GitPanel
+              branch={git.branch()}
+              ahead={git.upstream()?.ahead ?? 0}
+              behind={git.upstream()?.behind ?? 0}
+              changes={git.changes()}
+              cursor={panes.gitCursor()}
+              focused={panes.focus() === 'tree'}
+              width={settings.treeWidth()}
+              inRepo={inRepository(rootDir)}
+              onFocus={() => panes.setFocus('tree')}
+              onActivate={index => {
+                panes.setGitCursor(index)
+                const file = git.changes()[index]
+                if (file) actions.gitDiffAll(file.path)
+              }}
+            />
+          </Show>
           {/* Drag handle: the whole column is the grab target, but only a short
               grip is drawn at its middle — a full-height rule is a heavy line
               down the screen for something you touch once. The spacers centre it

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -6,7 +6,6 @@ import { createSignal, For, onCleanup, onMount, Show } from 'solid-js'
 
 import type { Config } from '../core/config'
 import { watchTree } from '../core/fs'
-import { inRepository } from '../core/git'
 import { checkForUpdate } from '../core/update'
 import { languageLabel } from '../languages'
 import { filetypeForPath } from '../languages/highlight'
@@ -253,7 +252,7 @@ export function App(props: {
               cursor={panes.gitCursor()}
               focused={panes.focus() === 'tree'}
               width={settings.treeWidth()}
-              inRepo={inRepository(rootDir)}
+              inRepo={git.inRepo()}
               onFocus={() => panes.setFocus('tree')}
               onActivate={index => {
                 panes.setGitCursor(index)

--- a/src/app/Overlays.tsx
+++ b/src/app/Overlays.tsx
@@ -248,7 +248,7 @@ export function OverlayStack(props: { ctx: AppContext; commands: Accessor<Comman
         )}
       </Show>
       <Show when={overlays.peek()}>
-        <KeyPeek pane={panes.focus()} />
+        <KeyPeek pane={panes.keyPane()} />
       </Show>
       <Show when={overlays.help()}>
         <HelpOverlay />

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -95,6 +95,7 @@ export function createCommands(ctx: AppContext) {
     prevTab: () => workspace.switchTab(-1),
     toggleFocus: () => (panes.focus() === 'tree' ? panes.setFocus('editor') : panes.focusTree()),
     toggleSidebar: panes.toggleSidebar,
+    toggleGitView: panes.toggleGitView,
     setVim: settings.applyVim,
     setTabSize: settings.applyTabSize,
     setTheme: settings.applyTheme,
@@ -112,14 +113,15 @@ export function createCommands(ctx: AppContext) {
       ctx.overlays.setDiff({ files: [file], index: 0 })
       panes.setFocus('editor')
     },
-    gitDiffAll: () => {
+    gitDiffAll: (focusPath?: string) => {
       if (!inRepository(rootDir)) return say('Not a git repository', 'warn')
       const files = [...statusMap(rootDir)]
         .map(([path, fileStatus]) => diffFileFor(path, fileStatus))
         .filter((file): file is DiffFile => file !== null)
         .toSorted((a, b) => a.rel.localeCompare(b.rel))
       if (files.length === 0) return say('Nothing to diff — working tree clean')
-      const active = files.findIndex(file => file.path === workspace.activePath())
+      const target = focusPath ?? workspace.activePath()
+      const active = files.findIndex(file => file.path === target)
       ctx.overlays.setDiff({ files, index: Math.max(0, active) })
       panes.setFocus('editor')
     },
@@ -164,7 +166,7 @@ export function createCommands(ctx: AppContext) {
     quit: ctx.prompts.quit,
   }
 
-  return createMemo<Command[]>(() =>
+  const commands = createMemo<Command[]>(() =>
     buildCommands(actions, {
       vimEnabled: config.vim,
       activeTheme: config.theme,
@@ -173,4 +175,6 @@ export function createCommands(ctx: AppContext) {
       autoSaveOnBlur: config.autoSaveOnBlur,
     }),
   )
+
+  return { commands, actions }
 }

--- a/src/app/commands.ts
+++ b/src/app/commands.ts
@@ -47,6 +47,7 @@ export interface CommandActions {
   prevTab: () => void
   toggleFocus: () => void
   toggleSidebar: () => void
+  toggleGitView: () => void
   setVim: (enabled: boolean) => void
   setTabSize: (size: number) => void
   setTheme: (name: ThemeName) => void
@@ -54,7 +55,7 @@ export interface CommandActions {
   toggleTrim: () => void
   toggleAutoSave: () => void
   gitDiffFile: () => void
-  gitDiffAll: () => void
+  gitDiffAll: (focusPath?: string) => void
   gitCommit: () => void
   gitUndoCommit: () => void
   gitPush: () => void
@@ -160,6 +161,12 @@ export function buildCommands(actions: CommandActions, ctx: CommandContext): Com
           label: 'Toggle sidebar',
           hint: 'Ctrl+B',
           run: actions.toggleSidebar,
+        },
+        {
+          id: 'view.git',
+          label: 'Source control (commit / push)',
+          hint: `Ctrl+${ALT}+G`,
+          run: actions.toggleGitView,
         },
         {
           id: 'view.focus',

--- a/src/app/git.ts
+++ b/src/app/git.ts
@@ -17,6 +17,10 @@ export function createGit(rootDir: string) {
   const [revision, setRevision] = createSignal(0)
   const [gitStatus, setGitStatus] = createSignal<Map<string, FileStatus>>(new Map())
   const [branch, setBranch] = createSignal(currentBranch(rootDir))
+  /** Whether `rootDir` is in a repository at all. A signal because `inRepository`
+   * spawns git: the source-control panel reads this on every render, and a
+   * subprocess there would run once per frame. */
+  const [inRepo, setInRepo] = createSignal(inRepository(rootDir))
   const [upstream, setUpstream] = createSignal<Upstream | null>(null)
   /** A git mutation in flight — one at a time, they share a repository. */
   const [gitBusy, setGitBusy] = createSignal(false)
@@ -41,6 +45,8 @@ export function createGit(rootDir: string) {
     setGitStatus,
     branch,
     setBranch,
+    inRepo,
+    setInRepo,
     upstream,
     setUpstream,
     gitBusy,
@@ -129,6 +135,9 @@ export function wireGitEffects(deps: {
       () => {
         git.setGitStatus(statusMap(rootDir))
         git.setBranch(currentBranch(rootDir))
+        // `git init` in another terminal writes .git, so the watcher brings us
+        // here — the only place the panel would ever learn it has a repository.
+        git.setInRepo(inRepository(rootDir))
       },
     ),
   )

--- a/src/app/git.ts
+++ b/src/app/git.ts
@@ -1,4 +1,6 @@
-import { createEffect, createSignal, on } from 'solid-js'
+import { relative } from 'node:path'
+
+import { createEffect, createMemo, createSignal, on } from 'solid-js'
 
 import { currentBranch, diffLines, inRepository, statusMap, upstreamOf } from '../core/git'
 import type { FileStatus, GitResult, LineChange, Upstream } from '../core/git'
@@ -23,6 +25,13 @@ export function createGit(rootDir: string) {
 
   const bump = () => setRevision(n => n + 1)
 
+  /** The changed files as the source-control panel lists them, in path order. */
+  const changes = createMemo(() =>
+    [...gitStatus()]
+      .map(([path, status]) => ({ path, rel: relative(rootDir, path), status }))
+      .toSorted((a, b) => a.rel.localeCompare(b.rel)),
+  )
+
   return {
     gitLines,
     setGitLines,
@@ -38,6 +47,7 @@ export function createGit(rootDir: string) {
     setGitBusy,
     commitPick,
     setCommitPick,
+    changes,
   }
 }
 

--- a/src/app/keyboard.ts
+++ b/src/app/keyboard.ts
@@ -3,14 +3,15 @@ import { dirname } from 'node:path'
 import type { KeyEvent } from '@opentui/core'
 import { useKeyboard } from '@opentui/solid'
 
+import type { CommandActions } from './commands'
 import type { AppContext } from './context'
 
 /** True for Ctrl+Opt+<key>, however this terminal spells the second modifier. */
 const chord = (key: KeyEvent) => key.shift || key.option || key.meta
 
 /** The global keymap: everything that fires before the focused pane sees the key. */
-export function installKeyboard(ctx: AppContext) {
-  const { settings, tree, panes, editor, workspace, fileOps, prompts, overlays } = ctx
+export function installKeyboard(ctx: AppContext, actions: CommandActions) {
+  const { settings, tree, panes, editor, workspace, fileOps, prompts, overlays, git } = ctx
   const { config } = settings
 
   useKeyboard((key: KeyEvent) => {
@@ -53,6 +54,9 @@ export function installKeyboard(ctx: AppContext) {
     if (key.ctrl && chord(key) && k === 't') return claim(workspace.reopenTab)
     // Ctrl+E is line-end in every terminal; keep the tab family on the arrows.
     if (key.ctrl && (k === 't' || k === 'up')) return claim(() => overlays.setPicker('tabs'))
+    // VS Code's Ctrl+Shift+G, in the spelling every terminal can send (see the
+    // project-search note below): show or hide the source-control panel.
+    if (key.ctrl && chord(key) && k === 'g') return claim(panes.toggleGitView)
     if (key.ctrl && k === 'g') return claim(() => prompts.setPrompt({ kind: 'gotoLine' }))
     if (key.ctrl && k === 's') return claim(workspace.saveActive)
     // Ctrl+Shift+<letter> is byte-identical to Ctrl+<letter> outside the kitty
@@ -109,8 +113,49 @@ export function installKeyboard(ctx: AppContext) {
     // Solid applies focus synchronously, so without this the key that opens a
     // file also reaches the freshly focused textarea.
     key.preventDefault()
-    const node = tree.selectedNode()
     const vimNav: Record<string, string> = { h: 'left', j: 'down', k: 'up', l: 'right' }
+
+    // The source-control panel borrows the tree's focus slot, so its keys replace
+    // the tree's while it shows — or `d` would still offer to delete files.
+    if (panes.view() === 'git') {
+      const files = git.changes()
+      const clamp = (row: number) => Math.max(0, Math.min(row, files.length - 1))
+      switch (config.vim ? (vimNav[k] ?? k) : k) {
+        case 'tab':
+          if (workspace.activePath() || overlays.diff()) panes.setFocus('editor')
+          break
+        case 'up':
+          panes.setGitCursor(at => clamp(at - 1))
+          break
+        case 'down':
+          panes.setGitCursor(at => clamp(at + 1))
+          break
+        case 'return':
+        case 'enter': {
+          const file = files[clamp(panes.gitCursor())]
+          if (file) actions.gitDiffAll(file.path)
+          break
+        }
+        case 'c':
+          actions.gitCommit()
+          break
+        case 'p':
+          actions.gitPush()
+          break
+        case '[':
+          settings.nudgeSidebar(-2)
+          break
+        case ']':
+          settings.nudgeSidebar(2)
+          break
+        case 'escape':
+          panes.toggleGitView()
+          break
+      }
+      return
+    }
+
+    const node = tree.selectedNode()
     switch (config.vim ? (vimNav[k] ?? k) : k) {
       case 'tab':
         // The diff page counts as an editor to hand focus to, file open or not.

--- a/src/app/panes.ts
+++ b/src/app/panes.ts
@@ -3,10 +3,15 @@ import { createSignal } from 'solid-js'
 import type { Tree } from './tree'
 import type { Focus } from './types'
 
-/** Which pane the keyboard belongs to, and whether the sidebar is on screen. */
+/** Which pane the keyboard belongs to, whether the sidebar is on screen, and
+ * which of its two views — the file tree or the source-control panel — it shows. */
 export function createPanes(tree: Tree, initialSidebar: boolean) {
   const [sidebar, setSidebar] = createSignal(initialSidebar)
   const [focus, setFocus] = createSignal<Focus>(initialSidebar ? 'tree' : 'editor')
+  const [view, setView] = createSignal<'files' | 'git'>('files')
+  /** Row under the cursor in the source-control panel; clamped where it is read,
+   * because the change list shrinks under it on every commit. */
+  const [gitCursor, setGitCursor] = createSignal(0)
 
   // Focus is useless without a visible cursor: a file opened from the picker or a
   // tab may sit in a collapsed folder, leaving no row to highlight.
@@ -26,10 +31,34 @@ export function createPanes(tree: Tree, initialSidebar: boolean) {
       return
     }
     setSidebar(true)
-    focusTree()
+    if (view() === 'files') focusTree()
+    else setFocus('tree')
   }
 
-  return { sidebar, focus, setFocus, focusTree, toggleSidebar }
+  /** Ctrl+Opt+G, as VS Code's Ctrl+Shift+G: show the panel, or put the tree back. */
+  const toggleGitView = () => {
+    if (sidebar() && view() === 'git') {
+      setView('files')
+      focusTree()
+      return
+    }
+    setView('git')
+    setSidebar(true)
+    setFocus('tree')
+  }
+
+  return {
+    sidebar,
+    focus,
+    setFocus,
+    focusTree,
+    toggleSidebar,
+    view,
+    setView,
+    toggleGitView,
+    gitCursor,
+    setGitCursor,
+  }
 }
 
 export type Panes = ReturnType<typeof createPanes>

--- a/src/app/panes.ts
+++ b/src/app/panes.ts
@@ -1,5 +1,6 @@
 import { createSignal } from 'solid-js'
 
+import type { KeyScope } from '../ui/keys'
 import type { Tree } from './tree'
 import type { Focus } from './types'
 
@@ -16,6 +17,10 @@ export function createPanes(tree: Tree, initialSidebar: boolean) {
   // Focus is useless without a visible cursor: a file opened from the picker or a
   // tab may sit in a collapsed folder, leaving no row to highlight.
   const focusTree = () => {
+    // The source-control panel borrows this focus slot. Revealing here would
+    // expand folders in a tree that is not on screen, and the expansion would
+    // still be there when it comes back.
+    if (view() === 'git') return setFocus('tree')
     const path = tree.selectedPath()
     if (path) tree.reveal(path)
     if (!tree.nodes().some(n => n.path === tree.selectedPath())) {
@@ -31,8 +36,7 @@ export function createPanes(tree: Tree, initialSidebar: boolean) {
       return
     }
     setSidebar(true)
-    if (view() === 'files') focusTree()
-    else setFocus('tree')
+    focusTree()
   }
 
   /** Ctrl+Opt+G, as VS Code's Ctrl+Shift+G: show the panel, or put the tree back. */
@@ -44,8 +48,12 @@ export function createPanes(tree: Tree, initialSidebar: boolean) {
     }
     setView('git')
     setSidebar(true)
-    setFocus('tree')
+    focusTree()
   }
+
+  /** Which keymap is live, for the peek strip: the panel has its own keys and
+   * shows under the tree's focus. */
+  const keyPane = (): KeyScope => (focus() === 'tree' && view() === 'git' ? 'git' : focus())
 
   return {
     sidebar,
@@ -54,8 +62,8 @@ export function createPanes(tree: Tree, initialSidebar: boolean) {
     focusTree,
     toggleSidebar,
     view,
-    setView,
     toggleGitView,
+    keyPane,
     gitCursor,
     setGitCursor,
   }

--- a/src/ui/GitPanel.tsx
+++ b/src/ui/GitPanel.tsx
@@ -1,0 +1,129 @@
+import { TextAttributes } from '@opentui/core'
+import { useTerminalDimensions } from '@opentui/solid'
+import { createMemo, For, Show } from 'solid-js'
+
+import type { FileStatus } from '../core/git'
+import { ui } from '../themes'
+import { MARKS, statusColor } from './FileTree'
+
+export interface GitChange {
+  path: string
+  /** Shown to the user; `path` is what git gets. */
+  rel: string
+  status: FileStatus
+}
+
+export interface GitPanelProps {
+  branch: string | null
+  /** Commits ahead of / behind the upstream, for the header. */
+  ahead: number
+  behind: number
+  changes: GitChange[]
+  /** Row under the cursor; may point past the end after a commit shrinks the list. */
+  cursor: number
+  focused: boolean
+  width: number
+  inRepo: boolean
+  onFocus: () => void
+  /** A row clicked: move the cursor there and open its diff. */
+  onActivate: (index: number) => void
+}
+
+/**
+ * The sidebar's source-control view — VS Code's left-hand git panel, sized down:
+ * the changed files under the branch, Enter for a diff, `c` to commit, `p` to
+ * push. Keys are handled in `app/keyboard.ts` beside the tree's, so this renders
+ * and reports clicks, nothing more.
+ */
+export function GitPanel(props: GitPanelProps) {
+  const dimensions = useTerminalDimensions()
+
+  const cursor = () => Math.max(0, Math.min(props.cursor, props.changes.length - 1))
+
+  /**
+   * A window over the rows, following the cursor. Change lists are usually
+   * shorter than the screen, but `git status` after a big refactor is not —
+   * and a cursor below the fold reads as no cursor at all.
+   */
+  const window = createMemo(() => {
+    // Header (2) + hint line (1) + tabs/status chrome (3).
+    const rows = Math.max(3, dimensions().height - 6)
+    const start = Math.max(0, Math.min(cursor() - rows + 1, props.changes.length - rows))
+    return { start, rows: props.changes.slice(start, start + rows) }
+  })
+
+  const headline = () => {
+    if (!props.inRepo) return 'not a git repository'
+    const arrows =
+      (props.ahead > 0 ? ` ↑${props.ahead}` : '') + (props.behind > 0 ? ` ↓${props.behind}` : '')
+    return `${props.branch ?? 'no branch'}${arrows}`
+  }
+
+  return (
+    <box
+      width={props.width}
+      flexDirection="column"
+      backgroundColor={ui.panelBg}
+      flexShrink={0}
+      onMouseDown={() => props.onFocus()}
+    >
+      <box height={2} flexDirection="column" backgroundColor={ui.panelBg} paddingLeft={2}>
+        <text
+          fg={props.focused ? ui.text : ui.dim}
+          bg={ui.panelBg}
+          content={headline()}
+          attributes={TextAttributes.BOLD}
+        />
+        <text fg={ui.faint} bg={ui.panelBg} content="source control" />
+      </box>
+      <Show
+        when={props.inRepo && props.changes.length > 0}
+        fallback={
+          <box flexGrow={1} backgroundColor={ui.panelBg} paddingLeft={2}>
+            <text
+              fg={ui.faint}
+              bg={ui.panelBg}
+              content={props.inRepo ? 'no changes' : 'open a repository to use git'}
+            />
+          </box>
+        }
+      >
+        <box flexGrow={1} flexDirection="column" backgroundColor={ui.panelBg}>
+          <For each={window().rows}>
+            {(change, row) => {
+              const index = () => window().start + row()
+              const selected = () => index() === cursor()
+              const bg = () =>
+                selected() ? (props.focused ? ui.treeSelectedBg : ui.treeFocusBg) : ui.panelBg
+              return (
+                <box
+                  height={1}
+                  flexDirection="row"
+                  backgroundColor={bg()}
+                  onMouseDown={() => props.onActivate(index())}
+                >
+                  {/* The name is the only thing allowed to give, as in the tree:
+                      shrinking the mark slid every row's glyphs around. */}
+                  <box flexGrow={1} flexDirection="row" backgroundColor={bg()}>
+                    <text fg={ui.text} bg={bg()} content={` ${change.rel}`} />
+                  </box>
+                  <text
+                    fg={statusColor(change.status)}
+                    bg={bg()}
+                    flexShrink={0}
+                    content={`${MARKS[change.status]} `}
+                  />
+                </box>
+              )
+            }}
+          </For>
+        </box>
+      </Show>
+      <Show when={props.inRepo}>
+        <box height={1} backgroundColor={ui.panelBg} paddingLeft={1}>
+          <text fg={ui.faint} bg={ui.panelBg} content="enter diff · c commit · p push" />
+        </box>
+      </Show>
+    </box>
+  )
+}

--- a/src/ui/GitPanel.tsx
+++ b/src/ui/GitPanel.tsx
@@ -1,6 +1,6 @@
 import { TextAttributes } from '@opentui/core'
 import { useTerminalDimensions } from '@opentui/solid'
-import { createMemo, For, Show } from 'solid-js'
+import { createEffect, createMemo, createSignal, For, Show } from 'solid-js'
 
 import type { FileStatus } from '../core/git'
 import { ui } from '../themes'
@@ -40,17 +40,32 @@ export function GitPanel(props: GitPanelProps) {
 
   const cursor = () => Math.max(0, Math.min(props.cursor, props.changes.length - 1))
 
+  // Header (2) + hint line (1) + tabs/status chrome (3).
+  const pageRows = () => Math.max(3, dimensions().height - 6)
+
   /**
-   * A window over the rows, following the cursor. Change lists are usually
-   * shorter than the screen, but `git status` after a big refactor is not —
-   * and a cursor below the fold reads as no cursor at all.
+   * First row on screen. Change lists are usually shorter than the panel, but
+   * `git status` after a big refactor is not, and a cursor below the fold reads
+   * as no cursor at all.
    */
-  const window = createMemo(() => {
-    // Header (2) + hint line (1) + tabs/status chrome (3).
-    const rows = Math.max(3, dimensions().height - 6)
-    const start = Math.max(0, Math.min(cursor() - rows + 1, props.changes.length - rows))
-    return { start, rows: props.changes.slice(start, start + rows) }
+  const [top, setTop] = createSignal(0)
+
+  // The window moves only when the cursor leaves it, as the tree's scrollbox does.
+  // Deriving the start from the cursor alone instead scrolls on every keypress,
+  // pinning the selected row to the bottom of the panel.
+  createEffect(() => {
+    const rows = pageRows()
+    const at = cursor()
+    const total = props.changes.length
+    setTop(previous => {
+      const start = Math.max(0, Math.min(previous, total - rows))
+      if (at < start) return at
+      if (at >= start + rows) return at - rows + 1
+      return start
+    })
   })
+
+  const visible = createMemo(() => props.changes.slice(top(), top() + pageRows()))
 
   const headline = () => {
     if (!props.inRepo) return 'not a git repository'
@@ -89,9 +104,9 @@ export function GitPanel(props: GitPanelProps) {
         }
       >
         <box flexGrow={1} flexDirection="column" backgroundColor={ui.panelBg}>
-          <For each={window().rows}>
+          <For each={visible()}>
             {(change, row) => {
-              const index = () => window().start + row()
+              const index = () => top() + row()
               const selected = () => index() === cursor()
               const bg = () =>
                 selected() ? (props.focused ? ui.treeSelectedBg : ui.treeFocusBg) : ui.panelBg

--- a/src/ui/KeyPeek.tsx
+++ b/src/ui/KeyPeek.tsx
@@ -4,10 +4,17 @@ import { createMemo, For } from 'solid-js'
 
 import { ui } from '../themes'
 import { keysFor } from './keys'
+import type { KeyScope } from './keys'
 import { PAD } from './modal'
 
 /** Columns between one key/label pair and the next. */
 const GAP = 3
+
+const SCOPE_LABELS: Record<KeyScope, string> = {
+  tree: 'file tree',
+  editor: 'editor',
+  git: 'source control',
+}
 
 const clip = (label: string, width: number) =>
   label.length > width ? `${label.slice(0, width - 1)}…` : label
@@ -17,7 +24,7 @@ const clip = (label: string, width: number) =>
  * the status bar. Opened by a key and closed by the next one, so it reads as
  * "hold to see" without needing key-release events no classic terminal sends.
  */
-export function KeyPeek(props: { pane: 'tree' | 'editor' }) {
+export function KeyPeek(props: { pane: KeyScope }) {
   const dimensions = useTerminalDimensions()
 
   const layout = createMemo(() => {
@@ -56,7 +63,7 @@ export function KeyPeek(props: { pane: 'tree' | 'editor' }) {
       border
       borderStyle="rounded"
       borderColor={ui.accent}
-      title={` Keys · ${props.pane === 'tree' ? 'file tree' : 'editor'} `}
+      title={` Keys · ${SCOPE_LABELS[props.pane]} `}
       titleColor={ui.text}
       paddingLeft={PAD}
       paddingRight={PAD}

--- a/src/ui/keys.ts
+++ b/src/ui/keys.ts
@@ -10,6 +10,10 @@
 
 type Pane = 'tree' | 'editor'
 
+/** The panes plus the sidebar's other view: the source-control panel replaces the
+ * tree's keys while it shows, so the peek strip has to tell the two apart. */
+export type KeyScope = Pane | 'git'
+
 /** What the key next to the space bar is called on this machine's keyboard. */
 export const ALT = process.platform === 'darwin' ? 'Opt' : 'Alt'
 
@@ -19,7 +23,7 @@ export interface KeyInfo {
   /** Heading the help overlay files this under. */
   section: string
   /** Pane(s) the key is alive in; 'help' rows show in the help table only. */
-  where: Pane | 'all' | 'help'
+  where: KeyScope | 'all' | 'help'
   /** Footer advertisement: which pane shows it, as what, in what order.
    * `key` overrides the display key where the full spelling is too wide. */
   hint?: { pane: Pane | 'all'; label: string; rank: number; key?: string }
@@ -113,11 +117,20 @@ export const KEYS: KeyInfo[] = [
     section: 'Source control',
     where: 'all',
   },
+  // Short labels on purpose: a label that wraps costs the help table a second row,
+  // and the table only just fits a 60-row terminal — `test/help-scroll.test.tsx`
+  // measures exactly that.
   {
     key: 'Enter · c · p',
-    label: 'Diff / commit… / push (in git panel)',
+    label: 'Diff / commit… / push',
     section: 'Source control',
-    where: 'help',
+    where: 'git',
+  },
+  {
+    key: '↑↓ · Esc',
+    label: 'Move / back to the file tree',
+    section: 'Source control',
+    where: 'git',
   },
 
   {
@@ -158,6 +171,6 @@ export function hintsFor(pane: Pane): ReadonlyArray<readonly [string, string]> {
 }
 
 /** Everything alive in `pane`, for the peek strip. */
-export function keysFor(pane: Pane): KeyInfo[] {
+export function keysFor(pane: KeyScope): KeyInfo[] {
   return KEYS.filter(info => info.where === pane || info.where === 'all')
 }

--- a/src/ui/keys.ts
+++ b/src/ui/keys.ts
@@ -108,6 +108,19 @@ export const KEYS: KeyInfo[] = [
   { key: '[ / ]', label: 'Narrow / widen sidebar (in tree)', section: 'File tree', where: 'tree' },
 
   {
+    key: `Ctrl+${ALT}+G`,
+    label: 'Source control panel (git)',
+    section: 'Source control',
+    where: 'all',
+  },
+  {
+    key: 'Enter · c · p',
+    label: 'Diff / commit… / push (in git panel)',
+    section: 'Source control',
+    where: 'help',
+  },
+
+  {
     key: 'Ctrl+B',
     label: 'Show / hide sidebar',
     section: 'View',

--- a/test/git-panel.test.tsx
+++ b/test/git-panel.test.tsx
@@ -1,0 +1,92 @@
+import { expect, test } from 'bun:test'
+import { writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { fixture, launch, press, pressEscape, settle } from './helpers'
+import type { Harness } from './helpers'
+
+const ESC = String.fromCharCode(27)
+/** Ctrl+Opt+G as terminals spell it: an ESC prefix ahead of Ctrl+G (0x07). */
+const TOGGLE = `${ESC}${String.fromCharCode(7)}`
+
+const git = (dir: string, ...args: string[]) => {
+  const run = Bun.spawnSync(['git', ...args], { cwd: dir })
+  if (run.exitCode !== 0) throw new Error(run.stderr.toString())
+}
+
+/** A repository with one commit and one modified file, so the panel has a row. */
+function repo() {
+  const dir = fixture({ 'a.ts': 'alpha\n', 'b.ts': 'beta\n' })
+  git(dir, 'init', '-q')
+  git(dir, 'config', 'user.email', 'druk@test')
+  git(dir, 'config', 'user.name', 'druk')
+  git(dir, 'config', 'commit.gpgsign', 'false')
+  git(dir, 'add', '.')
+  git(dir, 'commit', '-qm', 'init')
+  writeFileSync(join(dir, 'a.ts'), 'alpha changed\n')
+  return dir
+}
+
+const frame = (t: Harness) => t.captureCharFrame()
+
+test('Ctrl+Opt+G shows the changed files, Esc puts the tree back', async () => {
+  const t = await launch(repo())
+  await press(t, i => void i.pressKeys([TOGGLE]))
+
+  const open = frame(t)
+  expect(open).toContain('source control')
+  expect(open).toContain('a.ts')
+  expect(open).not.toContain('explorer')
+
+  await pressEscape(t)
+  expect(frame(t)).toContain('explorer')
+})
+
+test('outside a repository the panel says so instead of listing nothing', async () => {
+  const t = await launch(fixture({ 'a.ts': 'alpha\n' }))
+  await press(t, i => void i.pressKeys([TOGGLE]))
+  expect(frame(t)).toContain('open a repository to use git')
+})
+
+test('Enter opens the diff for the file under the cursor', async () => {
+  const t = await launch(repo())
+  await press(t, i => void i.pressKeys([TOGGLE]))
+  await press(t, i => i.pressEnter())
+  await settle(t, 100)
+
+  const shown = frame(t)
+  expect(shown).toContain('alpha changed')
+  expect(shown).toContain('+1 −1')
+})
+
+test('c commits the change from the panel, p reports on push', async () => {
+  const dir = repo()
+  const t = await launch(dir)
+  await press(t, i => void i.pressKeys([TOGGLE]))
+
+  // Commit: the file picker, then the message prompt, then a clean panel.
+  await press(t, i => void i.typeText('c'))
+  expect(frame(t)).toContain('Commit — 1 of 1 files')
+  await press(t, i => i.pressEnter())
+  expect(frame(t)).toContain('Commit message')
+  await press(t, i => void i.typeText('panel commit'))
+  await press(t, i => i.pressEnter())
+  await settle(t, 200)
+
+  expect(frame(t)).toContain('no changes')
+  const log = Bun.spawnSync(['git', 'log', '-1', '--format=%s'], { cwd: dir })
+  expect(log.stdout.toString().trim()).toBe('panel commit')
+
+  // Push has no remote to reach; the point is that `p` runs it and reports.
+  await press(t, i => void i.typeText('p'))
+  await settle(t, 300)
+  expect(frame(t)).not.toContain('explorer') // still in the panel, no paste happened
+})
+
+test('the palette opens the panel too', async () => {
+  const t = await launch(repo())
+  await press(t, i => i.pressKey('p', { ctrl: true }))
+  await press(t, i => void i.typeText('Source control'))
+  await press(t, i => i.pressEnter())
+  expect(frame(t)).toContain('source control')
+})

--- a/test/git-panel.test.tsx
+++ b/test/git-panel.test.tsx
@@ -83,6 +83,17 @@ test('c commits the change from the panel, p reports on push', async () => {
   expect(frame(t)).not.toContain('explorer') // still in the panel, no paste happened
 })
 
+test('the peek strip advertises the panel keys, not the tree ones', async () => {
+  const t = await launch(repo())
+  await press(t, i => void i.pressKeys([TOGGLE]))
+  await press(t, i => i.pressKey('k', { ctrl: true }))
+
+  const peek = frame(t)
+  expect(peek).toContain('Keys · source control')
+  expect(peek).toContain('Enter · c · p')
+  expect(peek).not.toContain('a / A')
+})
+
 test('the palette opens the panel too', async () => {
   const t = await launch(repo())
   await press(t, i => i.pressKey('p', { ctrl: true }))

--- a/test/hotkeys.test.tsx
+++ b/test/hotkeys.test.tsx
@@ -63,6 +63,11 @@ test('every advertised hotkey does something', async () => {
   await press(t, i => i.pressKey('t', { ctrl: true }))
   check('Ctrl+T switch tab', frame(t).includes('Switch tab'))
 
+  // Ctrl+Opt+G: ESC prefix ahead of Ctrl+G (0x07).
+  t = await tree()
+  await press(t, i => void i.pressKeys([`${ESC}${String.fromCharCode(7)}`]))
+  check('Ctrl+Opt+G source control', frame(t).includes('source control'))
+
   t = await tree()
   await press(t, i => i.pressKey('b', { ctrl: true }))
   check('Ctrl+B sidebar', !frame(t).includes('explorer'))


### PR DESCRIPTION
A small source-control panel in the sidebar, like VS Code's left-hand git view: the changed files listed under the branch name and its ahead/behind counts.

- `Ctrl+Opt+G` (VS Code's `Ctrl+Shift+G` family — the `Ctrl+Opt` spelling every terminal can send, same reasoning as the existing project-search chord) swaps the file tree for the panel; `Esc` puts the tree back. Also in the palette under *View → Source control*.
- `↑`/`↓` (or `j`/`k` in vim mode) move, `Enter` opens the file's diff — the existing diff page, landed on that file. Clicking a row does the same.
- `c` runs the existing commit flow (file picker → message prompt), `p` pushes. Both are the palette's own actions, not a second implementation: `createCommands` now returns the actions object beside the palette memo, and `gitDiffAll` grew an optional focus path.
- The panel is pure render + click callbacks; its keys live in `app/keyboard.ts` beside the tree's, replacing them while the panel shows (so `d` doesn't offer to delete files). Outside a repository it says so instead of listing nothing.

Tests (`test/git-panel.test.tsx`, against a real `git init` fixture): toggle shows the changed file and Esc restores the tree, the no-repo message, Enter opens the diff with the changed line visible, and a full commit from the panel — picker, message, `git log` showing the new subject, panel reading *no changes* after. The palette route is covered too.

Verified with `check-types`, `lint`, `format` and the affected test files (hotkeys/ui/unit/git-panel, 23 pass).