### PR TITLE
fix: bound the binary download so installs cannot hang

### DIFF
--- a/bin/binary.mjs
+++ b/bin/binary.mjs
@@ -63,12 +63,17 @@ export function findBinary() {
   return existsSync(local) ? local : null
 }
 
-/** Download and unpack the release asset. Returns the path, or null if it could not. */
-export async function fetchBinary() {
+/**
+ * Download and unpack the release asset. Returns the path, or null if it could not.
+ * `timeout` (ms) bounds the whole download — headers and body both, since a stalled
+ * body is how a slow mirror hangs an install forever.
+ */
+export async function fetchBinary({ timeout } = {}) {
   if (!supported) return null
   const temp = join(tmpdir(), `druk-${version}-${process.pid}`)
   try {
-    const response = await fetch(url, { redirect: 'follow' })
+    const signal = timeout ? AbortSignal.timeout(timeout) : undefined
+    const response = await fetch(url, { redirect: 'follow', signal })
     if (!response.ok) return null
     mkdirSync(temp, { recursive: true })
     const archive = join(temp, asset)

--- a/bin/druk.js
+++ b/bin/druk.js
@@ -18,9 +18,10 @@ if (!binary) {
     process.exit(1)
   }
   // Install skipped its scripts, or had no network then. Say so — this takes seconds
-  // and silence would look like a hang.
+  // and silence would look like a hang. Bounded so a stalled download ends in the
+  // actionable error below instead of hanging forever.
   process.stderr.write(`druk: fetching the ${target} binary for ${version}…\n`)
-  binary = await fetchBinary()
+  binary = await fetchBinary({ timeout: 300_000 })
 }
 
 if (!binary) {

--- a/bin/postinstall.mjs
+++ b/bin/postinstall.mjs
@@ -7,6 +7,12 @@
  * exit code is always zero — installing something that merely depends on druk must not
  * break because a download did.
  */
-import { fetchBinary, findBinary, supported } from './binary.mjs'
+import { fetchBinary, findBinary, supported, target } from './binary.mjs'
 
-if (supported && !findBinary()) await fetchBinary()
+// Bounded: an install must never hang on a stalled download (undici waits on a
+// trickling body for hours, and pnpm shows only "Running postinstall script…").
+// Giving up here costs nothing — the shim fetches again on first run.
+if (supported && !findBinary()) {
+  process.stderr.write(`druk: fetching the ${target} binary…\n`)
+  await fetchBinary({ timeout: 60_000 })
+}

--- a/test/postinstall.test.ts
+++ b/test/postinstall.test.ts
@@ -10,9 +10,14 @@ const stalled = createServer((_req, res) => {
   res.writeHead(200, { 'content-type': 'application/octet-stream' })
   res.write('partial')
 })
-silent.listen(0, '127.0.0.1')
-stalled.listen(0, '127.0.0.1')
-await Promise.all([once(silent, 'listening'), once(stalled, 'listening')])
+// Answers at once, with nothing to download.
+const missing = createServer((_req, res) => {
+  res.writeHead(404)
+  res.end()
+})
+const servers = [silent, stalled, missing]
+for (const server of servers) server.listen(0, '127.0.0.1')
+await Promise.all(servers.map(server => once(server, 'listening')))
 
 function port(server: Server) {
   const address = server.address()
@@ -33,29 +38,49 @@ function closeServer(server: Server) {
 }
 
 afterAll(async () => {
-  await Promise.all([closeServer(silent), closeServer(stalled)])
+  await Promise.all(servers.map(server => closeServer(server)))
 })
 
 // binary.mjs bakes DRUK_DOWNLOAD_BASE into its URL at module evaluation, so each
 // base needs its own import: env first, then a cache-busted dynamic import.
-async function fetchBinaryAgainst(server: Server) {
+async function binaryAgainst(server: Server) {
   process.env.DRUK_DOWNLOAD_BASE = `http://127.0.0.1:${port(server)}`
-  const { fetchBinary } = await import(`../bin/binary.mjs?base=${port(server)}`)
-  return fetchBinary
+  return import(`../bin/binary.mjs?base=${port(server)}`)
 }
 
 describe('fetchBinary timeout', () => {
+  test('the machine running the suite has a binary to fetch', async () => {
+    // On a target with no release asset fetchBinary returns before it reaches the
+    // network, and every test below would pass without exercising a timeout at all.
+    const { supported } = await binaryAgainst(missing)
+    expect(supported).toBe(true)
+  })
+
   test('gives up when the server never answers', async () => {
-    const fetchBinary = await fetchBinaryAgainst(silent)
+    const { fetchBinary } = await binaryAgainst(silent)
     const started = Date.now()
     expect(await fetchBinary({ timeout: 250 })).toBeNull()
-    expect(Date.now() - started).toBeLessThan(5_000)
+    const elapsed = Date.now() - started
+    // Waiting out the bound is the point: returning early would mean the connection
+    // was refused and the null proved nothing.
+    expect(elapsed).toBeGreaterThanOrEqual(200)
+    expect(elapsed).toBeLessThan(5_000)
   })
 
   test('gives up when the body stalls after headers', async () => {
-    const fetchBinary = await fetchBinaryAgainst(stalled)
+    const { fetchBinary } = await binaryAgainst(stalled)
     const started = Date.now()
     expect(await fetchBinary({ timeout: 250 })).toBeNull()
+    const elapsed = Date.now() - started
+    expect(elapsed).toBeGreaterThanOrEqual(200)
+    expect(elapsed).toBeLessThan(5_000)
+  })
+
+  test('a server that answers is not held to the bound', async () => {
+    // The 60s an install may spend waiting must not also be 60s of not installing.
+    const { fetchBinary } = await binaryAgainst(missing)
+    const started = Date.now()
+    expect(await fetchBinary({ timeout: 60_000 })).toBeNull()
     expect(Date.now() - started).toBeLessThan(5_000)
   })
 })

--- a/test/postinstall.test.ts
+++ b/test/postinstall.test.ts
@@ -1,0 +1,61 @@
+import { afterAll, describe, expect, test } from 'bun:test'
+import { once } from 'node:events'
+import type { Server } from 'node:http'
+import { createServer } from 'node:http'
+
+// Accepts the request and never responds: headers never arrive.
+const silent = createServer(() => {})
+// Headers arrive, the body never finishes — the shape of a stalled mirror.
+const stalled = createServer((_req, res) => {
+  res.writeHead(200, { 'content-type': 'application/octet-stream' })
+  res.write('partial')
+})
+silent.listen(0, '127.0.0.1')
+stalled.listen(0, '127.0.0.1')
+await Promise.all([once(silent, 'listening'), once(stalled, 'listening')])
+
+function port(server: Server) {
+  const address = server.address()
+  if (address && typeof address === 'object') return address.port
+  throw new Error('server is not listening on a TCP port')
+}
+
+function closeServer(server: Server) {
+  server.closeAllConnections()
+  // Bun's http close reports ERR_SERVER_NOT_RUNNING even after a clean
+  // listen/close pair (verified on 1.3.14); anything else is a real failure.
+  return new Promise<void>((resolve, reject) => {
+    server.close(error => {
+      if (error && !('code' in error && error.code === 'ERR_SERVER_NOT_RUNNING')) reject(error)
+      else resolve()
+    })
+  })
+}
+
+afterAll(async () => {
+  await Promise.all([closeServer(silent), closeServer(stalled)])
+})
+
+// binary.mjs bakes DRUK_DOWNLOAD_BASE into its URL at module evaluation, so each
+// base needs its own import: env first, then a cache-busted dynamic import.
+async function fetchBinaryAgainst(server: Server) {
+  process.env.DRUK_DOWNLOAD_BASE = `http://127.0.0.1:${port(server)}`
+  const { fetchBinary } = await import(`../bin/binary.mjs?base=${port(server)}`)
+  return fetchBinary
+}
+
+describe('fetchBinary timeout', () => {
+  test('gives up when the server never answers', async () => {
+    const fetchBinary = await fetchBinaryAgainst(silent)
+    const started = Date.now()
+    expect(await fetchBinary({ timeout: 250 })).toBeNull()
+    expect(Date.now() - started).toBeLessThan(5_000)
+  })
+
+  test('gives up when the body stalls after headers', async () => {
+    const fetchBinary = await fetchBinaryAgainst(stalled)
+    const started = Date.now()
+    expect(await fetchBinary({ timeout: 250 })).toBeNull()
+    expect(Date.now() - started).toBeLessThan(5_000)
+  })
+})


### PR DESCRIPTION
## Problem

`pnpx druk` (and any npm/pnpm install) could sit forever at:

```
node_modules/.pnpm/druk@1.6.0/node_modules/druk: Running postinstall script...
```

The postinstall fetches the ~50 MB platform binary from the GitHub release with no timeout and no output. Node's fetch (undici) waits on a trickling body indefinitely, so on a slow or throttled connection to `release-assets.githubusercontent.com` the install looks frozen — and is, for as long as the connection dribbles.

## Fix

- `fetchBinary({ timeout })` bounds the whole download — headers *and* body — with `AbortSignal.timeout`. The timer is unref'ed, so a fast success/404 still exits immediately.
- **postinstall**: bounded to 60 s and prints one `druk: fetching the <target> binary…` line to stderr. Giving up is free: the shim fetches again on first run, as designed.
- **first run** (`druk.js`): bounded to 5 minutes, so a stalled download ends in the existing actionable error (manual download / curl installer) instead of hanging at `druk: fetching…`.

## Verification

- New `test/postinstall.test.ts`: fetch gives up promptly against a server that never answers, and against one that sends headers then stalls the body.
- End-to-end: `node bin/postinstall.mjs` against a stalled local mirror exits 0 at exactly 60 s (previously: never).
- `check-types`, `lint`, `format:check` clean. Impacted tests (`postinstall`, `upgrade`, `cli`) pass; the full UI suite couldn't complete on my machine due to unrelated load-induced timeouts.