### PR TITLE
fix(install): avoid ETXTBSY when self-updating a running druk

### DIFF
--- a/install
+++ b/install
@@ -176,7 +176,21 @@ fi
 exe_name="$APP"
 case "$(uname -s)" in MINGW*|MSYS*|CYGWIN*) exe_name="$APP.exe" ;; esac
 
-staged=$(mktemp "$INSTALL_DIR/.$exe_name.XXXXXX")
+# The binary is replaced with mv, not cp: rename(2) swaps the directory entry
+# without touching the old inode, so it works while that inode is the running
+# druk doing the update (cp would get ETXTBSY). Unlike cp, mv replaces a
+# symlink instead of writing through it — druk owns this path, so a symlink
+# here is someone else's setup we refuse to break.
+if [ -L "$INSTALL_DIR/$exe_name" ]; then
+    echo -e "${RED}Error: $INSTALL_DIR/$exe_name is a symlink; refusing to replace it${NC}" >&2
+    echo -e "${MUTED}Remove the symlink and re-run the installer${NC}" >&2
+    exit 1
+fi
+
+if ! staged=$(mktemp "$INSTALL_DIR/.$exe_name.XXXXXX"); then
+    echo -e "${RED}Error: cannot write to $INSTALL_DIR${NC}" >&2
+    exit 1
+fi
 trap 'rm -rf "${tmp_dir:-}" "$staged"' EXIT
 cp "$binary_path" "$staged"
 chmod 755 "$staged"

--- a/install
+++ b/install
@@ -176,8 +176,11 @@ fi
 exe_name="$APP"
 case "$(uname -s)" in MINGW*|MSYS*|CYGWIN*) exe_name="$APP.exe" ;; esac
 
-cp "$binary_path" "$INSTALL_DIR/$exe_name"
-chmod 755 "$INSTALL_DIR/$exe_name"
+staged=$(mktemp "$INSTALL_DIR/.$exe_name.XXXXXX")
+trap 'rm -rf "${tmp_dir:-}" "$staged"' EXIT
+cp "$binary_path" "$staged"
+chmod 755 "$staged"
+mv -f "$staged" "$INSTALL_DIR/$exe_name"
 
 add_to_path() {
     local config_file=$1 command=$2

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import {
+  chmodSync,
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  readlinkSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const script = new URL('../install', import.meta.url).pathname
+
+const scratches: string[] = []
+function scratch() {
+  const dir = mkdtempSync(join(tmpdir(), 'druk-install-'))
+  scratches.push(dir)
+  return dir
+}
+afterEach(() => {
+  for (const dir of scratches.splice(0)) {
+    // A test may have made the install dir read-only; rm needs it writable again.
+    chmodSync(join(dir, 'bin'), 0o755)
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+function setup() {
+  const dir = scratch()
+  const bin = join(dir, 'bin')
+  mkdirSync(bin)
+  const next = join(dir, 'next-binary')
+  writeFileSync(next, '#!/bin/sh\necho v2\n', { mode: 0o755 })
+  return { dir, bin, next }
+}
+
+async function runInstall(installDir: string, binary: string) {
+  const proc = Bun.spawn(['bash', script, '--binary', binary, '--no-modify-path'], {
+    env: { ...process.env, DRUK_INSTALL_DIR: installDir },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+  return { stdout, stderr, exitCode }
+}
+
+// Root ignores file permissions, so the two failure tests would install fine and fail.
+const asRoot = process.getuid?.() === 0
+
+describe('install --binary', () => {
+  test('replaces the executable while it is the running process', async () => {
+    const { bin, next } = setup()
+    // The exact situation `druk update` creates: the destination is the text
+    // segment of a live process, which is what made the old in-place cp fail.
+    cpSync(Bun.which('sleep')!, join(bin, 'druk'))
+    const running = Bun.spawn([join(bin, 'druk'), '30'])
+    try {
+      const result = await runInstall(bin, next)
+      expect(result.exitCode).toBe(0)
+      expect(readFileSync(join(bin, 'druk'), 'utf8')).toContain('v2')
+      // The staging file must be gone — installed, not abandoned.
+      expect(readdirSync(bin)).toEqual(['druk'])
+    } finally {
+      running.kill()
+      await running.exited
+    }
+  })
+
+  test('refuses a symlinked destination and leaves it untouched', async () => {
+    const { dir, bin, next } = setup()
+    const referent = join(dir, 'real-druk')
+    writeFileSync(referent, 'someone else set this up', { mode: 0o755 })
+    symlinkSync(referent, join(bin, 'druk'))
+    const result = await runInstall(bin, next)
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr).toContain('symlink')
+    expect(readlinkSync(join(bin, 'druk'))).toBe(referent)
+    expect(readFileSync(referent, 'utf8')).toBe('someone else set this up')
+    expect(readdirSync(bin)).toEqual(['druk'])
+  })
+
+  test.skipIf(asRoot)('a copy that fails leaves the old binary and no staging file', async () => {
+    const { bin, next } = setup()
+    writeFileSync(join(bin, 'druk'), 'the version that works', { mode: 0o755 })
+    chmodSync(next, 0o000)
+    const result = await runInstall(bin, next)
+    expect(result.exitCode).not.toBe(0)
+    expect(readFileSync(join(bin, 'druk'), 'utf8')).toBe('the version that works')
+    expect(readdirSync(bin)).toEqual(['druk'])
+  })
+
+  test.skipIf(asRoot)('a non-writable install dir fails with a clear error', async () => {
+    const { bin, next } = setup()
+    writeFileSync(join(bin, 'druk'), 'the version that works', { mode: 0o755 })
+    chmodSync(bin, 0o555)
+    const result = await runInstall(bin, next)
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr).toContain(`cannot write to ${bin}`)
+    expect(readFileSync(join(bin, 'druk'), 'utf8')).toBe('the version that works')
+  })
+})


### PR DESCRIPTION
Problem:
`druk update` fails on a curl-script install:

```
$ druk update
Re-running the install script.
$ curl -fsSL https://druk.letstri.dev/install | bash

Installing druk 1.7.0 for linux-x64
cp: cannot create regular file '/home/sylverins/.druk/bin/druk': Text file busy

druk: update failed (exit 1)
```

Running the same curl manually works fine. The difference is that
druk update runs it while druk itself is the process executing that
update and install's last step overwrote the binary in place with cp,
which the kernel refuses (ETXTBSY) for a file that's currently the text
segment of a running process.

Fix:
druk update spawns this script while the running druk binary is still the process executing it. The final step overwrote that binary in place with cp, which the kernel refuses (ETXTBSY, 'Text file busy') because you can't truncate a file that's currently mapped as running code. Stage the new binary under a temp name in the same directory and mv it into place instead — rename(2) swaps the directory entry without touching the busy inode, so it works even while the old binary is still running.

Testing:
Reproduced the busy-file failure and verified the fix directly against a running "binary" on linux
```bash
S=/tmp/druk-selftest
mkdir -p "$S/bin"
cp /bin/sleep "$S/bin/druk"; cp /bin/sleep "$S/new-binary"
"$S/bin/druk" 60 &                     # simulate the running install

cp "$S/new-binary" "$S/bin/druk"
# -> cp: cannot create regular file '.../druk': Text file busy   (old bug)

DRUK_INSTALL_DIR="$S/bin" bash install --binary "$S/new-binary" --no-modify-path
echo $?                                # -> 0, binary replaced successfully
```
Also verified: `bash -n install` (syntax), and that a failure mid-copy
(unreadable source, simulating disk full) leaves no stray temp file behind.

Platforms: tested on linux only.