### PR TITLE
fix(languages): expand Go syntax highlighting

### DIFF
--- a/src/languages/queries/go.scm
+++ b/src/languages/queries/go.scm
@@ -1,12 +1,113 @@
-["break" "case" "const" "continue" "defer" "else" "for" "func" "go" "if" "import" "interface" "package" "range" "return" "select" "struct" "switch" "type" "var"] @keyword
-[(true) (false)] @boolean
-(comment) @comment
-[(interpreted_string_literal) (raw_string_literal)] @string
-(escape_sequence) @escape
-[(int_literal) (float_literal) (imaginary_literal)] @number
-[(nil) (iota)] @constant.builtin
+; Identifiers come first because equal-specificity captures later in the query
+; win when druk paints overlaps. The function rules below must override them.
+
 (type_identifier) @type
 (field_identifier) @property
+(identifier) @variable
 (label_name) @label
+
+; Function calls
+
+(call_expression
+  function: (identifier) @function)
+
+(call_expression
+  function: (identifier) @function.builtin
+  (#match? @function.builtin "^(append|cap|close|complex|copy|delete|imag|len|make|new|panic|print|println|real|recover)$"))
+
+(call_expression
+  function: (selector_expression
+    field: (field_identifier) @function.method))
+
+; Function definitions
+
+(function_declaration
+  name: (identifier) @function)
+
+(method_declaration
+  name: (field_identifier) @function.method)
+
+; Operators
+
+[
+  "--"
+  "-"
+  "-="
+  ":="
+  "!"
+  "!="
+  "..."
+  "*"
+  "*="
+  "/"
+  "/="
+  "&"
+  "&&"
+  "&="
+  "%"
+  "%="
+  "^"
+  "^="
+  "+"
+  "++"
+  "+="
+  "<-"
+  "<"
+  "<<"
+  "<<="
+  "<="
+  "="
+  "=="
+  ">"
+  ">="
+  ">>"
+  ">>="
+  "|"
+  "|="
+  "||"
+  "~"
+] @operator
+
+; Keywords
+
+[
+  "break"
+  "case"
+  "chan"
+  "const"
+  "continue"
+  "default"
+  "defer"
+  "else"
+  "fallthrough"
+  "for"
+  "func"
+  "go"
+  "goto"
+  "if"
+  "import"
+  "interface"
+  "map"
+  "package"
+  "range"
+  "return"
+  "select"
+  "struct"
+  "switch"
+  "type"
+  "var"
+] @keyword
+
+; Literals
+
+[(interpreted_string_literal) (raw_string_literal) (rune_literal)] @string
+(escape_sequence) @escape
+[(int_literal) (float_literal) (imaginary_literal)] @number
+[(true) (false)] @boolean
+[(nil) (iota)] @constant.builtin
+(comment) @comment
+
+; Punctuation
+
 ["{" "}" "(" ")" "[" "]"] @punctuation.bracket
 ["," ";" ":" "."] @punctuation.delimiter

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  filetypeForPath,
+  highlightClient,
+  segmentsIn,
+  styleIdForGroup,
+} from '../src/languages/highlight'
+import { parseHighlights, WHOLE } from './syntax'
+
+async function captured(source: string) {
+  const client = await highlightClient()
+  if (!client) throw new Error('tree-sitter client unavailable')
+  const result = await client.highlightOnce(source, 'go')
+  const byGroup = new Map<string, string[]>()
+  for (const [start, end, group] of result.highlights ?? []) {
+    byGroup.set(group, [...(byGroup.get(group) ?? []), source.slice(start, end)])
+  }
+  return (group: string) => byGroup.get(group) ?? []
+}
+
+const SOURCE = `package main
+
+import "fmt"
+
+var ready chan map[string]bool
+
+type server struct {
+  port int
+}
+
+func newServer(port int) *server {
+  return &server{port: port}
+}
+
+func (s *server) listen(addr string) error {
+  fmt.Println("listening", addr)
+  return nil
+}
+
+func main() {
+  s := newServer(8080)
+  _ = s.listen(':')
+  println("ready")
+}
+`
+
+describe('go highlighting', () => {
+  test('recognises .go files', () => {
+    expect(filetypeForPath('main.go')).toBe('go')
+    expect(filetypeForPath('cmd/server/main.go')).toBe('go')
+  })
+
+  test('paints declarations, calls, builtins and operators', async () => {
+    const group = await captured(SOURCE)
+
+    expect(group('function')).toContain('newServer')
+    expect(group('function.method')).toContain('listen')
+    expect(group('function.method')).toContain('Println')
+    expect(group('function.builtin')).toContain('println')
+    expect(group('variable')).toContain('addr')
+    expect(group('operator')).toContain(':=')
+    expect(group('keyword')).toContain('chan')
+    expect(group('keyword')).toContain('map')
+    expect(group('string')).toContain("':'")
+    expect(group('constant.builtin')).toContain('nil')
+  })
+
+  test('function captures win over generic identifiers when painted', async () => {
+    const parsed = await parseHighlights(SOURCE, 'go')
+    const lines = SOURCE.split('\n')
+    const functionStyle = styleIdForGroup('function')
+    if (functionStyle == null) throw new Error('function style unavailable')
+    const names = segmentsIn(parsed, 0, WHOLE)
+      .filter(segment => lines[segment.line]?.slice(segment.start, segment.end) === 'newServer')
+      .map(segment => segment.styleId)
+
+    expect(names).toEqual([functionStyle, functionStyle])
+  })
+})


### PR DESCRIPTION
## Summary

- expand the Go tree-sitter query to highlight function declarations and calls, methods, builtins, variables, operators, missing keywords, and rune literals
- order overlapping captures so function styles win over generic identifier styles
- add focused regression coverage for `.go` detection, semantic captures, and final painted styles

## Testing

- `bun test test/go.test.ts`
- `bun run check-types`
- `bun run lint` (passes with existing warnings)
- `bun run format:check`
- `bun test --parallel` (Go and language tests pass; unrelated file-watcher, clipboard, and process-timeout failures were also reproduced on an unchanged `origin/main` baseline in this local environment)
