### PR TITLE
fix: make global npm installs launch from PowerShell

### DIFF
--- a/bin/postinstall.mjs
+++ b/bin/postinstall.mjs
@@ -8,6 +8,7 @@
  * break because a download did.
  */
 import { fetchBinary, findBinary, supported, target } from './binary.mjs'
+import { removeWindowsBareShim } from './windows-shim.mjs'
 
 // Bounded: an install must never hang on a stalled download (undici waits on a
 // trickling body for hours, and pnpm shows only "Running postinstall script…").
@@ -16,3 +17,5 @@ if (supported && !findBinary()) {
   process.stderr.write(`druk: fetching the ${target} binary…\n`)
   await fetchBinary({ timeout: 60_000 })
 }
+
+removeWindowsBareShim()

--- a/bin/postinstall.mjs
+++ b/bin/postinstall.mjs
@@ -10,6 +10,10 @@
 import { fetchBinary, findBinary, supported, target } from './binary.mjs'
 import { removeWindowsBareShim } from './windows-shim.mjs'
 
+// Before the download, not after: an install cancelled during a slow fetch would
+// otherwise leave the launcher PowerShell cannot start.
+removeWindowsBareShim()
+
 // Bounded: an install must never hang on a stalled download (undici waits on a
 // trickling body for hours, and pnpm shows only "Running postinstall script…").
 // Giving up here costs nothing — the shim fetches again on first run.
@@ -17,5 +21,3 @@ if (supported && !findBinary()) {
   process.stderr.write(`druk: fetching the ${target} binary…\n`)
   await fetchBinary({ timeout: 60_000 })
 }
-
-removeWindowsBareShim()

--- a/bin/windows-shim.mjs
+++ b/bin/windows-shim.mjs
@@ -1,19 +1,34 @@
+/**
+ * Removing the launcher PowerShell cannot start.
+ *
+ * A global install on Windows leaves npm three launchers — `druk`, `druk.cmd` and
+ * `druk.ps1`. PowerShell matches the extensionless one before it ever consults PATHEXT
+ * and hands it to ShellExecute, which has no association for a file without an
+ * extension: `druk` opens the "how do you want to open this file?" dialog instead of
+ * the editor. Deleting it leaves the two launchers cmd.exe and PowerShell both resolve.
+ *
+ * The cost is MSYS shells — Git Bash and Cygwin run the extensionless sh shim and do no
+ * PATHEXT resolution of their own, so `druk` stops being a command there. That is the
+ * trade the dialog forces: the two native shells are the way in for nearly everyone.
+ */
 import { rmSync } from 'node:fs'
 import { join } from 'node:path'
 
 /**
- * PowerShell can resolve npm's extensionless POSIX shim before druk.cmd. Windows then
- * opens the extensionless file with ShellExecute instead of starting the editor.
- * npm_config_prefix is the directory that contains global Windows shims.
+ * npm exports `npm_config_global_prefix` to every script it runs, but `npm_config_prefix`
+ * only when the prefix differs from its default — so the latter is a fallback and never
+ * the test. On Windows the global launchers sit in the prefix itself, not `prefix/bin`.
  *
- * @param {{ platform?: NodeJS.Platform, global?: string, prefix?: string }} options
+ * @param {{ platform?: NodeJS.Platform, global?: string, location?: string, prefix?: string }} options
  */
 export function removeWindowsBareShim({
   platform = process.platform,
-  global = process.env.npm_config_global,
-  prefix = process.env.npm_config_prefix,
+  global: isGlobal = process.env.npm_config_global,
+  location = process.env.npm_config_location,
+  prefix = process.env.npm_config_global_prefix || process.env.npm_config_prefix,
 } = {}) {
-  if (platform !== 'win32' || global !== 'true' || !prefix) return
+  if (platform !== 'win32' || !prefix) return
+  if (isGlobal !== 'true' && location !== 'global') return
   try {
     rmSync(join(prefix, 'druk'))
   } catch {

--- a/bin/windows-shim.mjs
+++ b/bin/windows-shim.mjs
@@ -1,0 +1,22 @@
+import { rmSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * PowerShell can resolve npm's extensionless POSIX shim before druk.cmd. Windows then
+ * opens the extensionless file with ShellExecute instead of starting the editor.
+ * npm_config_prefix is the directory that contains global Windows shims.
+ *
+ * @param {{ platform?: NodeJS.Platform, global?: string, prefix?: string }} options
+ */
+export function removeWindowsBareShim({
+  platform = process.platform,
+  global = process.env.npm_config_global,
+  prefix = process.env.npm_config_prefix,
+} = {}) {
+  if (platform !== 'win32' || global !== 'true' || !prefix) return
+  try {
+    rmSync(join(prefix, 'druk'))
+  } catch {
+    // Best-effort: druk.cmd and druk.ps1 remain the supported Windows entry points.
+  }
+}

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -72,6 +72,7 @@ await mkdir(`${rootDir}/bin`, { recursive: true })
 await cp('./bin/druk.js', `${rootDir}/bin/druk.js`)
 await cp('./bin/postinstall.mjs', `${rootDir}/bin/postinstall.mjs`)
 await cp('./bin/binary.mjs', `${rootDir}/bin/binary.mjs`)
+await cp('./bin/windows-shim.mjs', `${rootDir}/bin/windows-shim.mjs`)
 await cp('./README.md', `${rootDir}/README.md`)
 
 const rootPkg = await Bun.file('./package.json').json()

--- a/test/postinstall.test.ts
+++ b/test/postinstall.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, describe, expect, test } from 'bun:test'
 import { once } from 'node:events'
+import { readdirSync } from 'node:fs'
 import type { Server } from 'node:http'
 import { createServer } from 'node:http'
 
@@ -82,5 +83,16 @@ describe('fetchBinary timeout', () => {
     const started = Date.now()
     expect(await fetchBinary({ timeout: 60_000 })).toBeNull()
     expect(Date.now() - started).toBeLessThan(5_000)
+  })
+})
+
+describe('the published package', () => {
+  // release.ts stages bin/ file by file, and `files: ['bin']` publishes whatever it
+  // staged: a module added here but not there leaves the shim importing nothing.
+  test('stages every module bin/ holds', async () => {
+    const release = await Bun.file(new URL('../scripts/release.ts', import.meta.url)).text()
+    const staged = [...release.matchAll(/cp\('\.\/bin\/([\w.-]+)'/g)].map(match => match[1])
+    const modules = readdirSync(new URL('../bin/', import.meta.url))
+    expect(staged.sort()).toEqual(modules.sort())
   })
 })

--- a/test/windows-shim.test.ts
+++ b/test/windows-shim.test.ts
@@ -14,6 +14,28 @@ async function shims() {
   return prefix
 }
 
+/** The suite itself runs from a package script, so npm_config_* is set — clear it. */
+function withNpmEnv(env: Record<string, string | undefined>, run: () => void) {
+  const keys = [
+    'npm_config_global',
+    'npm_config_location',
+    'npm_config_global_prefix',
+    'npm_config_prefix',
+  ]
+  const saved = Object.fromEntries(keys.map(key => [key, process.env[key]]))
+  try {
+    for (const key of keys) delete process.env[key]
+    for (const [key, value] of Object.entries(env))
+      if (value !== undefined) process.env[key] = value
+    run()
+  } finally {
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[key]
+      else process.env[key] = value
+    }
+  }
+}
+
 describe('Windows npm shim cleanup', () => {
   test('removes only the extensionless global shim on Windows', async () => {
     const prefix = await shims()
@@ -32,10 +54,43 @@ describe('Windows npm shim cleanup', () => {
     try {
       removeWindowsBareShim({ platform: 'linux', global: 'true', prefix: prefixes[0] })
       removeWindowsBareShim({ platform: 'win32', global: 'false', prefix: prefixes[1] })
-      removeWindowsBareShim({ platform: 'win32', global: 'true', prefix: undefined })
+      withNpmEnv({}, () => removeWindowsBareShim({ platform: 'win32', prefix: prefixes[2] }))
       expect(prefixes.every(prefix => existsSync(join(prefix, 'druk')))).toBe(true)
     } finally {
       await Promise.all(prefixes.map(prefix => rm(prefix, { recursive: true, force: true })))
+    }
+  })
+
+  // npm exports npm_config_global_prefix for every script it runs; npm_config_prefix
+  // only when the prefix is not npm's own default, which a plain `npm i -g` need not be.
+  test('takes the prefix npm exports unconditionally', async () => {
+    const [exported, overridden] = await Promise.all([shims(), shims()])
+    try {
+      withNpmEnv({ npm_config_global: 'true', npm_config_global_prefix: exported }, () =>
+        removeWindowsBareShim({ platform: 'win32' }),
+      )
+      expect(existsSync(join(exported, 'druk'))).toBe(false)
+
+      withNpmEnv({ npm_config_global: 'true', npm_config_prefix: overridden }, () =>
+        removeWindowsBareShim({ platform: 'win32' }),
+      )
+      expect(existsSync(join(overridden, 'druk'))).toBe(false)
+    } finally {
+      await Promise.all(
+        [exported, overridden].map(prefix => rm(prefix, { recursive: true, force: true })),
+      )
+    }
+  })
+
+  test('a global install spelled as a location is still global', async () => {
+    const prefix = await shims()
+    try {
+      withNpmEnv({ npm_config_location: 'global', npm_config_global_prefix: prefix }, () =>
+        removeWindowsBareShim({ platform: 'win32' }),
+      )
+      expect(existsSync(join(prefix, 'druk'))).toBe(false)
+    } finally {
+      await rm(prefix, { recursive: true, force: true })
     }
   })
 

--- a/test/windows-shim.test.ts
+++ b/test/windows-shim.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from 'bun:test'
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { removeWindowsBareShim } from '../bin/windows-shim.mjs'
+
+async function shims() {
+  const prefix = await mkdtemp(join(tmpdir(), 'druk-windows-shim-'))
+  for (const name of ['druk', 'druk.cmd', 'druk.ps1']) {
+    writeFileSync(join(prefix, name), name)
+  }
+  return prefix
+}
+
+describe('Windows npm shim cleanup', () => {
+  test('removes only the extensionless global shim on Windows', async () => {
+    const prefix = await shims()
+    try {
+      removeWindowsBareShim({ platform: 'win32', global: 'true', prefix })
+      expect(existsSync(join(prefix, 'druk'))).toBe(false)
+      expect(existsSync(join(prefix, 'druk.cmd'))).toBe(true)
+      expect(existsSync(join(prefix, 'druk.ps1'))).toBe(true)
+    } finally {
+      await rm(prefix, { recursive: true, force: true })
+    }
+  })
+
+  test('leaves shims alone outside a Windows global install', async () => {
+    const prefixes = await Promise.all([shims(), shims(), shims()])
+    try {
+      removeWindowsBareShim({ platform: 'linux', global: 'true', prefix: prefixes[0] })
+      removeWindowsBareShim({ platform: 'win32', global: 'false', prefix: prefixes[1] })
+      removeWindowsBareShim({ platform: 'win32', global: 'true', prefix: undefined })
+      expect(prefixes.every(prefix => existsSync(join(prefix, 'druk')))).toBe(true)
+    } finally {
+      await Promise.all(prefixes.map(prefix => rm(prefix, { recursive: true, force: true })))
+    }
+  })
+
+  test('does not fail when npm created no bare shim', async () => {
+    const prefix = await mkdtemp(join(tmpdir(), 'druk-windows-shim-'))
+    try {
+      mkdirSync(join(prefix, 'node_modules'))
+      expect(() =>
+        removeWindowsBareShim({ platform: 'win32', global: 'true', prefix }),
+      ).not.toThrow()
+    } finally {
+      await rm(prefix, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## Problem

A global npm install on Windows creates three launchers: `druk`, `druk.cmd`, and `druk.ps1`. On the affected PowerShell setup, the extensionless POSIX shim wins resolution and Windows opens an app-picker dialog instead of starting druk.

## Fix

- After postinstall, remove only the extensionless `druk` launcher for a **global Windows npm install**.
- Resolve the launcher directory from npm's own `npm_config_prefix`; local installs and non-Windows platforms are left untouched.
- Keep cleanup best-effort, preserving `druk.cmd` and `druk.ps1` as the supported Windows entry points.
- Include the helper in the staged npm package.

## Verification

- Added `test/windows-shim.test.ts`: Windows/global cleanup, `.cmd`/`.ps1` preservation, non-Windows/local no-op behavior, and missing-shim tolerance — **3 pass**.
- Existing `test/postinstall.test.ts` — **4 pass**.
- `bun run check-types`, `bun run lint`, and `bun run format:check` pass.
- `bun run release linux-x64` stages `windows-shim.mjs` in `dist/npm/druk/bin`; both staged modules pass `node --check`.
- Real Windows npm/PowerShell smoke test with a fixture package:
  - global install leaves `druk.cmd` and `druk.ps1`
  - extensionless `druk` is absent
  - `Get-Command druk` resolves `druk.ps1`
  - invoking `druk` prints the fixture's expected output
- Full isolated suite: 118/119 test files pass. `test/vim-visual.test.tsx` has one clipboard assertion failure (33 pass, 1 fail) that reproduces unchanged on a clean `main` tree in this WSL environment.

Closes #24
