### PR TITLE
feat(languages): Shopify Liquid syntax highlighting

### DIFF
--- a/src/languages/highlight.ts
+++ b/src/languages/highlight.ts
@@ -104,6 +104,7 @@ export function filetypeForPath(path: string): string | undefined {
   if (BY_NAME[name]) return BY_NAME[name]
   if (DOTENV.test(name)) return 'dotenv'
   if (name.endsWith('.tsrx')) return 'tsrx'
+  if (name.endsWith('.liquid')) return 'liquid'
   return pathToFiletype(path) ?? undefined
 }
 

--- a/src/languages/index.ts
+++ b/src/languages/index.ts
@@ -181,6 +181,7 @@ export const LANGUAGES: Language[] = [
       { group: 'keyword.operator', re: /==|!=|<=|>=/g },
       { group: 'operator', re: /\|(?=[ \t]*[a-zA-Z_])/g },
       { group: 'function', re: /(?<=\|[ \t]*)[a-zA-Z_]\w*/g },
+      { group: 'variable', re: /(?<=\b(?:assign|capture)\b[ \t]+)[a-zA-Z_]\w*/g },
       {
         group: 'comment.block',
         re: /\{%-?\s*comment\s*-?%\}[\s\S]*?\{%-?\s*endcomment\s*-?%\}|\{%-?\s*doc\s*-?%\}[\s\S]*?\{%-?\s*enddoc\s*-?%\}|\{%-?\s*#.*?-?%\}/g,

--- a/src/languages/index.ts
+++ b/src/languages/index.ts
@@ -165,26 +165,40 @@ export const LANGUAGES: Language[] = [
   {
     id: 'liquid',
     patterns: [
-      { group: 'comment', re: /<!--[\s\S]*?-->/g },
-      { group: 'string', re: /"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'/g },
       { group: 'attribute', re: /(?<=[\s<])[a-zA-Z_:][-\w:.]*(?=[ \t]*=[ \t]*["'])/g },
       { group: 'tag', re: /<\/?([A-Za-z][\w.-]*)/g },
-      { group: 'punctuation.bracket', re: /<\/?|\/?>/g },
       { group: 'operator', re: /=/g },
       { group: 'number', re: /\b\d+(?:\.\d+)?\b/g },
       { group: 'boolean', re: /\b(?:true|false|nil|blank|empty)\b/g },
-      { group: 'punctuation.special', re: /\{\{-?|-?\}\}|\{%-?|-?%\}/g },
       {
         group: 'keyword',
         re: /(?<=\{%-?\s*)\b(?:assign|capture|endcapture|case|when|endcase|cycle|decrement|echo|for|endfor|break|continue|if|elsif|else|endif|include|increment|layout|liquid|raw|endraw|render|section|sections|style|endstyle|tablerow|endtablerow|unless|endunless|paginate|endpaginate|form|endform|javascript|endjavascript|schema|endschema|stylesheet|endstylesheet|comment|endcomment)\b/g,
       },
+      // Either `{% assign x %}` or a bare `assign x` line inside `{% liquid %}`.
+      // Anchoring to one of those two is what keeps an English "capture it later"
+      // in the surrounding HTML prose from painting the next word as a variable.
+      { group: 'variable', re: /(?<=(?:\{%-?|^)[ \t]*(?:assign|capture)[ \t]+)[a-zA-Z_]\w*/gm },
+      // `(?<!\|)`/`(?!\|)`: a filter pipe is one bar. Without it the `b` of a
+      // JavaScript `a || b` in an embedded <script> paints as a filter.
+      { group: 'operator', re: /(?<!\|)\|(?!\|)(?=[ \t]*[a-zA-Z_])/g },
+      { group: 'function', re: /(?<=(?<!\|)\|[ \t]*)[a-zA-Z_]\w*/g },
+      // Last of the one-dot groups so a value's digits and words stay string
+      // coloured — `data-count="3"`, `class="empty"`. Single quotes need the
+      // preceding-letter guard and neither quote may cross a line: a theme file
+      // is mostly English, and "the customer's cart. Don't" otherwise pairs two
+      // apostrophes into a string that runs on until the next one.
+      {
+        group: 'string',
+        re: /"(?:[^"\\\n]|\\.)*"|(?<![A-Za-z0-9])'(?:[^'\\\n]|\\.)*'/g,
+      },
+      { group: 'punctuation.bracket', re: /<\/?|\/?>/g },
+      { group: 'punctuation.special', re: /\{\{-?|-?\}\}|\{%-?|-?%\}/g },
       { group: 'keyword.operator', re: /==|!=|<=|>=/g },
-      { group: 'operator', re: /\|(?=[ \t]*[a-zA-Z_])/g },
-      { group: 'function', re: /(?<=\|[ \t]*)[a-zA-Z_]\w*/g },
-      { group: 'variable', re: /(?<=\b(?:assign|capture)\b[ \t]+)[a-zA-Z_]\w*/g },
+      // Two dots, and after the delimiter patterns, so a comment keeps its own
+      // `<!--`/`{%` rather than losing them to bracket and Liquid punctuation.
       {
         group: 'comment.block',
-        re: /\{%-?\s*comment\s*-?%\}[\s\S]*?\{%-?\s*endcomment\s*-?%\}|\{%-?\s*doc\s*-?%\}[\s\S]*?\{%-?\s*enddoc\s*-?%\}|\{%-?\s*#.*?-?%\}/g,
+        re: /<!--[\s\S]*?-->|\{%-?\s*comment\s*-?%\}[\s\S]*?\{%-?\s*endcomment\s*-?%\}|\{%-?\s*doc\s*-?%\}[\s\S]*?\{%-?\s*enddoc\s*-?%\}|\{%-?\s*#.*?-?%\}/g,
       },
       { group: 'keyword.tag', re: /(?<=^[ \t]*)@\w+/gm },
       { group: 'type.builtin', re: /(?<=@param[ \t]*)\{[^{}]*\}/g },

--- a/src/languages/index.ts
+++ b/src/languages/index.ts
@@ -162,6 +162,34 @@ export const LANGUAGES: Language[] = [
       { group: 'comment', re: /^[ \t]*[#;].*/gm },
     ],
   },
+  {
+    id: 'liquid',
+    patterns: [
+      { group: 'comment', re: /<!--[\s\S]*?-->/g },
+      { group: 'string', re: /"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'/g },
+      { group: 'attribute', re: /(?<=[\s<])[a-zA-Z_:][-\w:.]*(?=[ \t]*=[ \t]*["'])/g },
+      { group: 'tag', re: /<\/?([A-Za-z][\w.-]*)/g },
+      { group: 'punctuation.bracket', re: /<\/?|\/?>/g },
+      { group: 'operator', re: /=/g },
+      { group: 'number', re: /\b\d+(?:\.\d+)?\b/g },
+      { group: 'boolean', re: /\b(?:true|false|nil|blank|empty)\b/g },
+      { group: 'punctuation.special', re: /\{\{-?|-?\}\}|\{%-?|-?%\}/g },
+      {
+        group: 'keyword',
+        re: /(?<=\{%-?\s*)\b(?:assign|capture|endcapture|case|when|endcase|cycle|decrement|echo|for|endfor|break|continue|if|elsif|else|endif|include|increment|layout|liquid|raw|endraw|render|section|sections|style|endstyle|tablerow|endtablerow|unless|endunless|paginate|endpaginate|form|endform|javascript|endjavascript|schema|endschema|stylesheet|endstylesheet|comment|endcomment)\b/g,
+      },
+      { group: 'keyword.operator', re: /==|!=|<=|>=/g },
+      { group: 'operator', re: /\|(?=[ \t]*[a-zA-Z_])/g },
+      { group: 'function', re: /(?<=\|[ \t]*)[a-zA-Z_]\w*/g },
+      {
+        group: 'comment.block',
+        re: /\{%-?\s*comment\s*-?%\}[\s\S]*?\{%-?\s*endcomment\s*-?%\}|\{%-?\s*doc\s*-?%\}[\s\S]*?\{%-?\s*enddoc\s*-?%\}|\{%-?\s*#.*?-?%\}/g,
+      },
+      { group: 'keyword.tag', re: /(?<=^[ \t]*)@\w+/gm },
+      { group: 'type.builtin', re: /(?<=@param[ \t]*)\{[^{}]*\}/g },
+      { group: 'variable.parameter', re: /(?<=@param[ \t]*\{[^{}]*\}[ \t]*)\[?[a-zA-Z_]\w*\]?/g },
+    ],
+  },
 ]
 
 /**

--- a/test/languages.test.ts
+++ b/test/languages.test.ts
@@ -135,6 +135,69 @@ describe('liquid doc comments', () => {
   })
 })
 
+describe('liquid assign targets', () => {
+  const SOURCE = [
+    '{%- liquid',
+    '  assign variant = current_variant | default: product.first_available_variant',
+    "  assign resolved_form_class = 'js-add-to-cart'",
+    '  if form_class != blank',
+    '    assign resolved_form_class = resolved_form_class | append: form_class',
+    '  endif',
+    '-%}',
+    '{% capture inline_label %}Add to cart{% endcapture %}',
+    '<div class="{{ resolved_form_class }}">{{ variant }}</div>',
+    '',
+  ].join('\n')
+
+  function styleAt(segs: Segment[], needle: string, occurrence = 0) {
+    let index = -1
+    for (let i = 0; i <= occurrence; i++) index = SOURCE.indexOf(needle, index + 1)
+    let acc = 0
+    const lines = SOURCE.split('\n')
+    for (let line = 0; line < lines.length; line++) {
+      const lineLen = lines[line]!.length
+      if (index <= acc + lineLen) {
+        const col = index - acc
+        return segs.find(s => s.line === line && col >= s.start && col < s.end)?.styleId
+      }
+      acc += lineLen + 1
+    }
+    return undefined
+  }
+
+  test('an assign target is styled as a variable whether its value is a bare reference, a filter chain, or a string literal', async () => {
+    const segs = await allSegments(SOURCE, 'liquid')
+    const ss = getSyntaxStyle()
+    const isStyle = (found: number | undefined, group: string) => found === ss.getStyleId(group)
+
+    expect(isStyle(styleAt(segs, 'variant = current_variant'), 'variable')).toBe(true)
+    expect(isStyle(styleAt(segs, "resolved_form_class = 'js-add-to-cart'"), 'variable')).toBe(true)
+    expect(isStyle(styleAt(segs, 'resolved_form_class = resolved_form_class'), 'variable')).toBe(
+      true,
+    )
+    expect(isStyle(styleAt(segs, 'inline_label'), 'variable')).toBe(true)
+  })
+
+  test('a reference to that name elsewhere is not mistaken for another declaration', async () => {
+    const segs = await allSegments(SOURCE, 'liquid')
+    const ss = getSyntaxStyle()
+
+    expect(styleAt(segs, 'form_class != blank')).not.toBe(ss.getStyleId('variable'))
+    expect(styleAt(segs, 'resolved_form_class', 2)).not.toBe(ss.getStyleId('variable'))
+    expect(styleAt(segs, 'resolved_form_class', 3)).not.toBe(ss.getStyleId('variable'))
+  })
+
+  test('real HTML attributes and filters are unaffected', async () => {
+    const segs = await allSegments(SOURCE, 'liquid')
+    const ss = getSyntaxStyle()
+    const isStyle = (found: number | undefined, group: string) => found === ss.getStyleId(group)
+
+    expect(isStyle(styleAt(segs, 'class="'), 'attribute')).toBe(true)
+    expect(isStyle(styleAt(segs, 'default:'), 'function')).toBe(true)
+    expect(isStyle(styleAt(segs, 'append:'), 'function')).toBe(true)
+  })
+})
+
 describe('abandoning a highlight that arrived too late', () => {
   const SOURCE = 'const alpha = 1 // note\n'
 

--- a/test/languages.test.ts
+++ b/test/languages.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test'
 
 import { LANGUAGES, languageFor, languageLabel } from '../src/languages'
 import { computeHighlights, getSyntaxStyle, segmentsIn, STALE } from '../src/languages/highlight'
-import type { Highlighted } from '../src/languages/highlight'
+import type { Highlighted, Segment } from '../src/languages/highlight'
 import { allSegments, parseHighlights, WHOLE } from './syntax'
 
 const SAMPLES: Record<string, string> = {
@@ -31,6 +31,7 @@ const SAMPLES: Record<string, string> = {
   scala: '// c\nobject A { def go(x: Int): Int = x }\n',
   yaml: '# c\na:\n  b: true\n',
   svelte: '<!-- c -->\n<script>let x = 1</script>\n<div class="a">{x}</div>\n',
+  liquid: '<!-- c -->\n<div class="a">{{ product.title | upcase }}</div>\n',
   sql: '-- c\nSELECT id FROM users WHERE age > 18;\n',
   ini: '; c\n[section]\nkey = value\n',
   dotenv: '# c\nexport PORT=3000\nURL="https://x.dev"\n',
@@ -79,6 +80,59 @@ describe('languages', () => {
       expect(segs.some(s => s.styleId === comment)).toBe(true)
     }, 15000)
   }
+})
+
+describe('liquid doc comments', () => {
+  const SOURCE = [
+    '{% doc %}',
+    '  Renders a reusable AJAX add-to-cart form and button.',
+    '',
+    '  @param {product} product - Shopify product object for the form.',
+    '  @param {variant} [current_variant] - Variant used for the initial button availability state.',
+    '',
+    '  @example',
+    "  {% render 'add-to-cart-form', product: product %}",
+    '{% enddoc %}',
+    '',
+  ].join('\n')
+
+  function styleAt(segs: Segment[], needle: string, occurrence = 0) {
+    let index = -1
+    for (let i = 0; i <= occurrence; i++) index = SOURCE.indexOf(needle, index + 1)
+    let acc = 0
+    const lines = SOURCE.split('\n')
+    for (let line = 0; line < lines.length; line++) {
+      const lineLen = lines[line]!.length
+      if (index <= acc + lineLen) {
+        const col = index - acc
+        return segs.find(s => s.line === line && col >= s.start && col < s.end)?.styleId
+      }
+      acc += lineLen + 1
+    }
+    return undefined
+  }
+
+  test('delimiters and prose default to comment, @param/@example stand out as tags, {type} as a type, and both the required and optional [name] form as a parameter', async () => {
+    const segs = await allSegments(SOURCE, 'liquid')
+    const ss = getSyntaxStyle()
+    const isStyle = (found: number | undefined, group: string) => found === ss.getStyleId(group)
+
+    expect(isStyle(styleAt(segs, '{% doc %}'), 'comment')).toBe(true)
+    expect(isStyle(styleAt(segs, 'Renders a reusable'), 'comment')).toBe(true)
+    expect(isStyle(styleAt(segs, '@param'), 'keyword.tag')).toBe(true)
+    expect(isStyle(styleAt(segs, '@example'), 'keyword.tag')).toBe(true)
+    expect(isStyle(styleAt(segs, '{product}'), 'type.builtin')).toBe(true)
+    expect(isStyle(styleAt(segs, '{variant}'), 'type.builtin')).toBe(true)
+    expect(isStyle(styleAt(segs, 'product', 1), 'variable.parameter')).toBe(true)
+    expect(isStyle(styleAt(segs, 'current_variant'), 'variable.parameter')).toBe(true)
+  })
+
+  test('the dotted groups above have no theme entry of their own, so the assertions above are exercising the fallback, not a coincidence', () => {
+    const ss = getSyntaxStyle()
+    expect(ss.getStyleId('keyword.tag')).toBe(ss.getStyleId('keyword'))
+    expect(ss.getStyleId('type.builtin')).toBe(ss.getStyleId('type'))
+    expect(ss.getStyleId('variable.parameter')).toBe(ss.getStyleId('variable'))
+  })
 })
 
 describe('abandoning a highlight that arrived too late', () => {

--- a/test/languages.test.ts
+++ b/test/languages.test.ts
@@ -82,6 +82,33 @@ describe('languages', () => {
   }
 })
 
+/**
+ * Style id painted over the `occurrence`-th `needle` in `source`, by its first
+ * character. Segment coordinates are per line, so the offset has to be walked
+ * back into a line and a column first.
+ */
+function styleLookup(source: string) {
+  const lines = source.split('\n')
+  return (segs: Segment[], needle: string, occurrence = 0) => {
+    let index = -1
+    for (let i = 0; i <= occurrence; i++) index = source.indexOf(needle, index + 1)
+    let acc = 0
+    for (let line = 0; line < lines.length; line++) {
+      const lineLen = lines[line]!.length
+      if (index < acc + lineLen) {
+        const col = index - acc
+        return segs.find(s => s.line === line && col >= s.start && col < s.end)?.styleId
+      }
+      acc += lineLen + 1
+    }
+    return undefined
+  }
+}
+
+/** `getStyleId` answers `number | null`, which `toBe` will not take. */
+const isStyle = (found: number | undefined, group: string) =>
+  found === getSyntaxStyle().getStyleId(group)
+
 describe('liquid doc comments', () => {
   const SOURCE = [
     '{% doc %}',
@@ -96,27 +123,10 @@ describe('liquid doc comments', () => {
     '',
   ].join('\n')
 
-  function styleAt(segs: Segment[], needle: string, occurrence = 0) {
-    let index = -1
-    for (let i = 0; i <= occurrence; i++) index = SOURCE.indexOf(needle, index + 1)
-    let acc = 0
-    const lines = SOURCE.split('\n')
-    for (let line = 0; line < lines.length; line++) {
-      const lineLen = lines[line]!.length
-      if (index <= acc + lineLen) {
-        const col = index - acc
-        return segs.find(s => s.line === line && col >= s.start && col < s.end)?.styleId
-      }
-      acc += lineLen + 1
-    }
-    return undefined
-  }
+  const styleAt = styleLookup(SOURCE)
 
   test('delimiters and prose default to comment, @param/@example stand out as tags, {type} as a type, and both the required and optional [name] form as a parameter', async () => {
     const segs = await allSegments(SOURCE, 'liquid')
-    const ss = getSyntaxStyle()
-    const isStyle = (found: number | undefined, group: string) => found === ss.getStyleId(group)
-
     expect(isStyle(styleAt(segs, '{% doc %}'), 'comment')).toBe(true)
     expect(isStyle(styleAt(segs, 'Renders a reusable'), 'comment')).toBe(true)
     expect(isStyle(styleAt(segs, '@param'), 'keyword.tag')).toBe(true)
@@ -149,27 +159,10 @@ describe('liquid assign targets', () => {
     '',
   ].join('\n')
 
-  function styleAt(segs: Segment[], needle: string, occurrence = 0) {
-    let index = -1
-    for (let i = 0; i <= occurrence; i++) index = SOURCE.indexOf(needle, index + 1)
-    let acc = 0
-    const lines = SOURCE.split('\n')
-    for (let line = 0; line < lines.length; line++) {
-      const lineLen = lines[line]!.length
-      if (index <= acc + lineLen) {
-        const col = index - acc
-        return segs.find(s => s.line === line && col >= s.start && col < s.end)?.styleId
-      }
-      acc += lineLen + 1
-    }
-    return undefined
-  }
+  const styleAt = styleLookup(SOURCE)
 
   test('an assign target is styled as a variable whether its value is a bare reference, a filter chain, or a string literal', async () => {
     const segs = await allSegments(SOURCE, 'liquid')
-    const ss = getSyntaxStyle()
-    const isStyle = (found: number | undefined, group: string) => found === ss.getStyleId(group)
-
     expect(isStyle(styleAt(segs, 'variant = current_variant'), 'variable')).toBe(true)
     expect(isStyle(styleAt(segs, "resolved_form_class = 'js-add-to-cart'"), 'variable')).toBe(true)
     expect(isStyle(styleAt(segs, 'resolved_form_class = resolved_form_class'), 'variable')).toBe(
@@ -189,12 +182,55 @@ describe('liquid assign targets', () => {
 
   test('real HTML attributes and filters are unaffected', async () => {
     const segs = await allSegments(SOURCE, 'liquid')
-    const ss = getSyntaxStyle()
-    const isStyle = (found: number | undefined, group: string) => found === ss.getStyleId(group)
-
     expect(isStyle(styleAt(segs, 'class="'), 'attribute')).toBe(true)
     expect(isStyle(styleAt(segs, 'default:'), 'function')).toBe(true)
     expect(isStyle(styleAt(segs, 'append:'), 'function')).toBe(true)
+  })
+})
+
+describe('liquid around the markup a theme file is mostly made of', () => {
+  const SOURCE = [
+    '<!-- section: cart -->',
+    '<div class="cart" data-count="3" id="cart-2">',
+    "  <p>It's the customer's cart. Don't panic.</p>",
+    '  <span>Buy one or capture it later.</span>',
+    '</div>',
+    '<script>',
+    '  const ok = alpha || beta',
+    '</script>',
+    '',
+  ].join('\n')
+
+  const styleAt = styleLookup(SOURCE)
+
+  test('an HTML comment keeps its own delimiters instead of losing them to the bracket pattern', async () => {
+    const segs = await allSegments(SOURCE, 'liquid')
+    expect(isStyle(styleAt(segs, '<!--'), 'comment')).toBe(true)
+    expect(isStyle(styleAt(segs, '-->'), 'comment')).toBe(true)
+  })
+
+  test('an attribute value stays one string, digits and all', async () => {
+    const segs = await allSegments(SOURCE, 'liquid')
+    expect(isStyle(styleAt(segs, '"3"'), 'string')).toBe(true)
+    expect(isStyle(styleAt(segs, '3'), 'string')).toBe(true)
+    expect(isStyle(styleAt(segs, '2'), 'string')).toBe(true)
+  })
+
+  test('apostrophes in prose do not pair into a string', async () => {
+    const segs = await allSegments(SOURCE, 'liquid')
+    expect(isStyle(styleAt(segs, "'s the customer"), 'string')).toBe(false)
+    expect(isStyle(styleAt(segs, 'the customer'), 'string')).toBe(false)
+  })
+
+  test('prose that happens to say "capture" does not declare a variable', async () => {
+    const segs = await allSegments(SOURCE, 'liquid')
+    expect(isStyle(styleAt(segs, 'it later'), 'variable')).toBe(false)
+  })
+
+  test('a JavaScript or in an embedded script is not read as a filter pipe', async () => {
+    const segs = await allSegments(SOURCE, 'liquid')
+    expect(isStyle(styleAt(segs, '|| beta'), 'operator')).toBe(false)
+    expect(isStyle(styleAt(segs, 'beta'), 'function')).toBe(false)
   })
 })
 


### PR DESCRIPTION
## Summary

Adds syntax highlighting for Shopify Liquid (`.liquid`) files.

There's no usable tree-sitter grammar to vendor here: the only actively
maintained one (`hankthetank27/tree-sitter-liquid`) parses Liquid tags but
not the surrounding HTML — its HTML support is an optional tree-sitter
*injection* query, and druk's highlighting pipeline runs one grammar per
file with no injection support. A `.liquid` file is usually mostly HTML, so
that grammar would leave most of the file unhighlighted. Regex `patterns`
cover both HTML structure and Liquid's `{{ }}` / `{% %}` constructs together
instead, the same way `svelte` already handles a similar HTML-plus-directives
mix with no grammar of its own.

**Covered:** tags/attributes, delimiters (including the `-` whitespace-control
variants), flow-control keywords (`if`/`unless`/`case`/`for`/`assign`/`render`/
`section`/etc.), filters (`| upcase`), strings, numbers, comparison operators,
and comments — both `{% comment %}...{% endcomment %}` and the newer inline
`{% # ... %}` form.

Keyword matching is anchored to right after an opening `{%`, which is what
keeps an English sentence — or a `for`/`if`/`break` inside an embedded
`<script>`'s real JS — from painting as a Liquid keyword. That costs the
mid-tag keywords (`in`, `contains`, `and`, `or`) and the multi-statement
`{% liquid %}` block, both of which are left unstyled rather than risk a
false match; I judged that trade worth it given how much plain English/HTML
content a real theme file carries.

**`{% doc %}...{% enddoc %}`** (a snippet's own doc comment) gets JSDoc-style
treatment layered on top of the base comment coloring: `@param`/`@example`
read as tags, the `{type}` annotation as a type, and the parameter name —
both the required and the optional `[name]` form — as a parameter. The
`@example` body itself stays comment-colored rather than being highlighted as
real Liquid code; doing that properly would need scoping a pattern to a
sub-range of the doc block, which felt like a separate, more invasive change.

I verified the pattern set against the real highlighting engine (not just
visually) — in particular the specificity/tie-break behavior that decides
which pattern wins when two of them match the same characters (e.g. a `{{ }}`
delimiter inside a quoted HTML attribute value, or the delimiters of a
comment block against the generic Liquid-delimiter pattern). The dotted group
names (`comment.block`, `keyword.tag`, `type.builtin`, `variable.parameter`)
exist purely to win those ties; they have no dedicated theme entries and fall
back to `comment`/`keyword`/`type`/`variable`, which the new tests assert
explicitly.

## Test plan

- [x] `bun run check` passes (types, lint, format, full test suite)
- [x] New `liquid` sample in `test/languages.test.ts`'s per-language highlight
      check
- [x] New `describe('liquid doc comments', ...)` block asserting the
      `{% doc %}`/`@param` styling against the real engine, including that the
      dotted groups genuinely fall back rather than coincidentally matching
- [x] Manually opened a real theme snippet (`add-to-cart-form.liquid`, with a
      `{% doc %}` block) via `bun run start` and confirmed the highlighting
      looks right

## Preview

Before:
<img width="2238" height="1824" alt="image" src="https://github.com/user-attachments/assets/ee938182-5acb-4b35-ab4c-eceae959ab84" />

After:
<img width="2272" height="1826" alt="image" src="https://github.com/user-attachments/assets/b074d375-245f-4094-b595-1ade2e439ceb" />