### PR TITLE
feat(editor): a setting for the caret shape

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,8 @@ installer — and run as a CLI.
 Features: file tree with bulk file operations and opt-in hiding of dotfiles and
 git-ignored files, preview/pinned tabs, tree-sitter syntax
 highlighting, search (current file and project-wide), command palette, themes, vim mode,
+a caret shape (`cursorStyle` — block, line or underline, which vim mode overrides while
+it is on, since there the shape is what tells normal from insert),
 git marks in tree/gutter/status bar plus a source-control panel in the sidebar
 (changed files as a folder tree or a flat list — `gitPanelView` — folders folding on
 → / ←) and palette commands for commit/undo/stash/push/fetch/pull and for branches

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ instead of breaking startup.
 | `theme` | `"dark"` | `dark`, `light`, `ayu-dark`, `ayu-mirage`, `ayu-light`, `catppuccin-mocha`, `catppuccin-macchiato`, `catppuccin-frappe`, `catppuccin-latte`, `dracula`, `everforest-dark`, `everforest-light`, `gruvbox`, `gruvbox-light`, `kanagawa-wave`, `kanagawa-dragon`, `kanagawa-lotus`, `nord`, `one-dark`, `rose-pine`, `rose-pine-moon`, `rose-pine-dawn`, `solarized-dark`, `solarized-light`, `tokyo-night`, `vesper` |
 | `transparent` | `false` | set `true` to leave the editor, tab strip and sidebar unpainted, so a translucent terminal shows through |
 | `tabSize` | `2` | 1–16 |
+| `cursorStyle` | `"block"` | `block`, `line` or `underline` — the caret's shape, which vim mode overrides while it is on, since there the shape is what tells normal from insert |
 | `vim` | `false` | normal / insert / visual modes, `hjkl w b 0 $ gg G`, counts, `i a o`, `x dd dw cw`, `v` + `d y c`, `yy p P`, `u` / `Ctrl+R` |
 | `sidebarWidth` | `"auto"` | a quarter of the window, or pin 15–80 columns |
 | `trimOnSave` | `false` | on save: strip trailing spaces and end the file with one newline |

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -532,6 +532,7 @@ export function App(props: {
             edit={editor.edit()}
             lineOp={editor.lineOp()}
             vim={config.vim}
+            cursorStyle={config.cursorStyle}
             tabSize={config.tabSize}
             gitLines={git.gitLines()}
             problems={problemLines()}

--- a/src/app/settings.ts
+++ b/src/app/settings.ts
@@ -31,6 +31,10 @@ import type { Status } from './status'
 const EDITOR_MIN = 20
 
 const TAB_SIZES = [2, 4, 8]
+/** The shapes OpenTUI draws. Its fourth, `default`, is left out: it defers to whatever
+ * the terminal was already set to, which is not a choice this row could show a value
+ * for. */
+const CURSOR_STYLES = ['block', 'line', 'underline'] as const
 const THEME_NAMES = Object.keys(THEMES) as ThemeName[]
 
 /** The entry `dir` steps to, wrapping at both ends. */
@@ -190,6 +194,11 @@ export function createSettings(deps: {
   const applyTabSize = (size: number) => {
     patchConfig({ tabSize: size })
     status.say(`Tab size: ${size}`)
+  }
+
+  const applyCursorStyle = (style: Config['cursorStyle']) => {
+    patchConfig({ cursorStyle: style })
+    status.say(config.vim ? `Cursor: ${style} — vim mode overrides it` : `Cursor: ${style}`)
   }
 
   const applyVim = (enabled: boolean) => {
@@ -558,6 +567,24 @@ export function createSettings(deps: {
       label: 'Vim mode',
       value: onOff(view().vim),
       cycle: () => applyVim(!view().vim),
+    },
+    {
+      section: 'Editor',
+      key: 'cursorStyle',
+      label: 'Cursor',
+      // Said on the row rather than left to the status line, which is gone by the time
+      // anyone wonders why the caret did not change.
+      //
+      // `config.vim` and not `view().vim`, unlike the value beside it: the note is about
+      // the caret actually on screen, and a project file pinning vim on overrides it
+      // whatever the user's own file says. The shape stays `view()`'s, because that is
+      // the value this page edits and marks as overridden.
+      value: config.vim ? `${view().cursorStyle} (vim overrides)` : view().cursorStyle,
+      cycle: dir => applyCursorStyle(step(CURSOR_STYLES, view().cursorStyle, dir)),
+      select: {
+        options: [...CURSOR_STYLES],
+        pick: at => applyCursorStyle(CURSOR_STYLES[at]!),
+      },
     },
     {
       section: 'Editor',

--- a/src/app/settings.ts
+++ b/src/app/settings.ts
@@ -5,6 +5,7 @@ import { APPEARANCE_ENV, detectAppearance } from '../core/appearance'
 import type { Appearance } from '../core/appearance'
 import {
   CONFIG_FILE,
+  CURSOR_STYLES,
   projectConfigFile,
   resolveConfig,
   saveProjectConfig,
@@ -31,10 +32,6 @@ import type { Status } from './status'
 const EDITOR_MIN = 20
 
 const TAB_SIZES = [2, 4, 8]
-/** The shapes OpenTUI draws. Its fourth, `default`, is left out: it defers to whatever
- * the terminal was already set to, which is not a choice this row could show a value
- * for. */
-const CURSOR_STYLES = ['block', 'line', 'underline'] as const
 const THEME_NAMES = Object.keys(THEMES) as ThemeName[]
 
 /** The entry `dir` steps to, wrapping at both ends. */

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -55,6 +55,14 @@ export function sidebarColumns(width: number | 'auto', terminalWidth: number): n
   return Math.max(AUTO_MIN, Math.min(AUTO_MAX, Math.round(terminalWidth * AUTO_SHARE)))
 }
 
+/**
+ * The caret shapes OpenTUI draws. Its fourth, `default`, is left out: it defers to
+ * whatever the terminal was already set to, which is not a choice a settings row
+ * could show a value for.
+ */
+export const CURSOR_STYLES = ['block', 'line', 'underline'] as const
+export type CursorStyle = (typeof CURSOR_STYLES)[number]
+
 export interface Config {
   /** Color scheme id — see src/themes. */
   theme: ThemeName
@@ -81,7 +89,7 @@ export interface Config {
    * Shape of the caret. Ignored while `vim` is on, where the shape is how you tell
    * normal from insert and the mode has to win.
    */
-  cursorStyle: 'block' | 'line' | 'underline'
+  cursorStyle: CursorStyle
   /**
    * Columns per indent level for space indentation — the Tab key and the guides.
    * A literal tab is two columns whatever this says: OpenTUI's renderer fixes that
@@ -223,7 +231,7 @@ const VALIDATORS: { [K in keyof Config]: Validator<K> } = {
   themeDark: theme,
   transparent: bool,
   vim: bool,
-  cursorStyle: among('block', 'line', 'underline'),
+  cursorStyle: among(...CURSOR_STYLES),
   tabSize: raw => (typeof raw === 'number' && raw >= 1 && raw <= 16 ? Math.floor(raw) : undefined),
   sidebarWidth: raw => {
     if (raw === 'auto') return 'auto'

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -78,6 +78,11 @@ export interface Config {
   /** Modal editing (normal / insert / visual). */
   vim: boolean
   /**
+   * Shape of the caret. Ignored while `vim` is on, where the shape is how you tell
+   * normal from insert and the mode has to win.
+   */
+  cursorStyle: 'block' | 'line' | 'underline'
+  /**
    * Columns per indent level for space indentation — the Tab key and the guides.
    * A literal tab is two columns whatever this says: OpenTUI's renderer fixes that
    * width and exposes no setting for it.
@@ -153,6 +158,8 @@ export const DEFAULTS: Config = {
   themeDark: 'dark',
   transparent: false,
   vim: false,
+  // OpenTUI's own default, so an unset key keeps the caret druk has always drawn.
+  cursorStyle: 'block',
   tabSize: 2,
   sidebarWidth: 'auto',
   skipUpdate: '',
@@ -216,6 +223,7 @@ const VALIDATORS: { [K in keyof Config]: Validator<K> } = {
   themeDark: theme,
   transparent: bool,
   vim: bool,
+  cursorStyle: among('block', 'line', 'underline'),
   tabSize: raw => (typeof raw === 'number' && raw >= 1 && raw <= 16 ? Math.floor(raw) : undefined),
   sidebarWidth: raw => {
     if (raw === 'auto') return 'auto'

--- a/src/ui/EditorPane.tsx
+++ b/src/ui/EditorPane.tsx
@@ -59,6 +59,8 @@ export interface EditorPaneProps {
   /** A line edit asked for from the palette; bumped `key` re-applies. */
   lineOp: { op: 'comment' | 'up' | 'down' | 'duplicate'; key: number } | null
   vim: boolean
+  /** Caret shape, for as long as vim is off — see the `cursorStyle` config key. */
+  cursorStyle: 'block' | 'line' | 'underline'
   tabSize: number
   /** True while a modal owns the keyboard; the editor must ignore all keys. */
   blocked: boolean
@@ -1482,6 +1484,17 @@ export function EditorPane(props: EditorPaneProps) {
               focusedBackgroundColor={ui.bg}
               focusedTextColor={ui.text}
               cursorColor={ui.cursor}
+              // Vim owns the caret while it is on: the shape is how normal and insert
+              // are told apart, so the setting yields to it rather than fighting the
+              // mode swap in the keyboard handler below. `vim` is reactive, so turning
+              // it off here is also what puts the user's own shape back — vim leaves
+              // the caret in whatever shape its last mode chose.
+              // `blinking: true` is OpenTUI's default, restated because this replaces
+              // the whole option object rather than one field of it.
+              cursorStyle={{
+                style: props.vim ? 'block' : props.cursorStyle,
+                blinking: true,
+              }}
               // Always wrapping: OpenTUI's textarea scrolls sideways only by
               // dragging the caret along, so unwrapped long lines have no way to be
               // read that does not move the cursor.

--- a/src/ui/EditorPane.tsx
+++ b/src/ui/EditorPane.tsx
@@ -4,6 +4,7 @@ import { useKeyboard, useRenderer, useTerminalDimensions } from '@opentui/solid'
 import { createEffect, createMemo, createSignal, For, Index, on, onCleanup, Show } from 'solid-js'
 
 import { copyToClipboard, readClipboard } from '../core/clipboard'
+import type { CursorStyle } from '../core/config'
 import type { LineChange } from '../core/git'
 import { changeRows } from '../editor/changes'
 import { History } from '../editor/history'
@@ -60,7 +61,7 @@ export interface EditorPaneProps {
   lineOp: { op: 'comment' | 'up' | 'down' | 'duplicate'; key: number } | null
   vim: boolean
   /** Caret shape, for as long as vim is off — see the `cursorStyle` config key. */
-  cursorStyle: 'block' | 'line' | 'underline'
+  cursorStyle: CursorStyle
   tabSize: number
   /** True while a modal owns the keyboard; the editor must ignore all keys. */
   blocked: boolean
@@ -264,6 +265,12 @@ export function EditorPane(props: EditorPaneProps) {
   /** Cursor offset before the edit in progress — where undo should land. */
   let cursorBeforeEdit = 0
   const vimState = initialVimState()
+  /**
+   * Vim's mode, mirrored as a signal. `vimState` is a plain object, so the caret's
+   * shape — which is how normal and insert are told apart — has nothing to derive
+   * itself from without this.
+   */
+  const [vimMode, setVimMode] = createSignal<VimMode>(vimState.mode)
 
   const [editorEl, setEditorEl] = createSignal<TextareaRenderable | null>(null)
   const [cursorLine, setCursorLine] = createSignal(0)
@@ -1235,10 +1242,7 @@ export function EditorPane(props: EditorPaneProps) {
     const stepped = { undo: () => stepHistory('undo'), redo: () => stepHistory('redo') }
     if (handleVimKey(editor, key, vimState, stepped)) key.preventDefault()
     if (vimState.mode !== before) {
-      editor.cursorStyle = {
-        style: vimState.mode === 'insert' ? 'line' : 'block',
-        blinking: true,
-      }
+      setVimMode(vimState.mode)
       props.onVimMode(vimState.mode)
     }
   })
@@ -1287,6 +1291,7 @@ export function EditorPane(props: EditorPaneProps) {
       () => [props.vim, props.path],
       () => {
         Object.assign(vimState, initialVimState())
+        setVimMode(vimState.mode)
         props.onVimMode(props.vim ? 'normal' : null)
       },
     ),
@@ -1485,14 +1490,15 @@ export function EditorPane(props: EditorPaneProps) {
               focusedTextColor={ui.text}
               cursorColor={ui.cursor}
               // Vim owns the caret while it is on: the shape is how normal and insert
-              // are told apart, so the setting yields to it rather than fighting the
-              // mode swap in the keyboard handler below. `vim` is reactive, so turning
-              // it off here is also what puts the user's own shape back — vim leaves
-              // the caret in whatever shape its last mode chose.
+              // are told apart, so the setting yields to it. Every input to the shape
+              // is read here rather than some of them assigned when the mode changes —
+              // this runs again whenever any of the three moves, so a `cursorStyle`
+              // edit made while vim sits in insert mode would otherwise repaint the
+              // caret block and leave it there until the next mode change.
               // `blinking: true` is OpenTUI's default, restated because this replaces
               // the whole option object rather than one field of it.
               cursorStyle={{
-                style: props.vim ? 'block' : props.cursorStyle,
+                style: props.vim ? (vimMode() === 'insert' ? 'line' : 'block') : props.cursorStyle,
                 blinking: true,
               }}
               // Always wrapping: OpenTUI's textarea scrolls sideways only by

--- a/test/cursor-style.test.tsx
+++ b/test/cursor-style.test.tsx
@@ -1,0 +1,87 @@
+import { expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+
+import { CONFIG_FILE } from '../src/core/config'
+import { fixture, launch, press, runCommand } from './helpers'
+import type { Harness } from './helpers'
+
+const PROJECT = { 'a.ts': 'const a = 1\n' }
+
+/** One flush per key — a burst in one chunk parses as fewer keys than were sent. */
+async function down(t: Harness, times: number) {
+  for (let step = 0; step < times; step++) await press(t, i => i.pressArrow('down'))
+}
+
+/**
+ * The caret's shape is a terminal property, not a glyph, so a captured frame cannot
+ * show it. What is assertable is the row and the file the row writes — and, for the
+ * vim rule, that the page says the setting is not in charge.
+ */
+const cursorRow = (t: Harness) =>
+  t
+    .captureCharFrame()
+    .split('\n')
+    .find(line => line.includes('Cursor'))!
+    .trimEnd()
+
+const savedStyle = () => JSON.parse(readFileSync(CONFIG_FILE, 'utf8')).cursorStyle
+
+/** Theme, Follow OS, Light, Dark, Transparent, Vim → Cursor. */
+const CURSOR_ROW = 6
+
+test('the cursor row starts on the block druk has always drawn', async () => {
+  const t = await launch(fixture(PROJECT))
+  await runCommand(t, 'Settings')
+  await down(t, CURSOR_ROW)
+  expect(cursorRow(t).endsWith('block')).toBe(true)
+})
+
+test('arrows cycle the caret shape in both directions, and it persists', async () => {
+  const t = await launch(fixture(PROJECT))
+  await runCommand(t, 'Settings')
+  await down(t, CURSOR_ROW)
+
+  await press(t, i => i.pressArrow('right'))
+  expect(cursorRow(t).endsWith('line')).toBe(true)
+  expect(savedStyle()).toBe('line')
+
+  await press(t, i => i.pressArrow('right'))
+  expect(cursorRow(t).endsWith('underline')).toBe(true)
+
+  await press(t, i => i.pressArrow('left'))
+  expect(cursorRow(t).endsWith('line')).toBe(true)
+  expect(savedStyle()).toBe('line')
+
+  // Wraps past the first entry rather than sticking.
+  await press(t, i => i.pressArrow('left'))
+  expect(cursorRow(t).endsWith('block')).toBe(true)
+  await press(t, i => i.pressArrow('left'))
+  expect(cursorRow(t).endsWith('underline')).toBe(true)
+})
+
+test('a saved shape is what the row comes back showing', async () => {
+  const t = await launch(fixture(PROJECT), { cursorStyle: 'line' })
+  await runCommand(t, 'Settings')
+  await down(t, CURSOR_ROW)
+  expect(cursorRow(t).endsWith('line')).toBe(true)
+})
+
+test('vim mode says on the row that it has taken the caret over', async () => {
+  const t = await launch(fixture(PROJECT), { vim: true, cursorStyle: 'line' })
+  await runCommand(t, 'Settings')
+  await down(t, CURSOR_ROW)
+  // The setting is still the user's, and still saved — it is only not in effect,
+  // which the row has to say or the caret looks broken.
+  expect(cursorRow(t)).toContain('line')
+  expect(cursorRow(t)).toContain('vim overrides')
+})
+
+test('the shape is still editable while vim holds the caret', async () => {
+  const t = await launch(fixture(PROJECT), { vim: true })
+  await runCommand(t, 'Settings')
+  await down(t, CURSOR_ROW)
+  await press(t, i => i.pressArrow('right'))
+  // Written for when vim is turned back off, not swallowed.
+  expect(savedStyle()).toBe('line')
+  expect(cursorRow(t)).toContain('vim overrides')
+})

--- a/test/cursor-style.test.tsx
+++ b/test/cursor-style.test.tsx
@@ -1,8 +1,11 @@
 import { expect, test } from 'bun:test'
 import { readFileSync } from 'node:fs'
 
+import { TextareaRenderable } from '@opentui/core'
+import type { Renderable } from '@opentui/core'
+
 import { CONFIG_FILE } from '../src/core/config'
-import { fixture, launch, press, runCommand } from './helpers'
+import { fixture, launch, openFile, press, pressEscape, runCommand } from './helpers'
 import type { Harness } from './helpers'
 
 const PROJECT = { 'a.ts': 'const a = 1\n' }
@@ -13,10 +16,23 @@ async function down(t: Harness, times: number) {
 }
 
 /**
- * The caret's shape is a terminal property, not a glyph, so a captured frame cannot
- * show it. What is assertable is the row and the file the row writes — and, for the
- * vim rule, that the page says the setting is not in charge.
+ * The caret's shape is a terminal property rather than a glyph, so a captured frame
+ * cannot show it — but the textarea it was set on is reachable from the harness, and
+ * that is the value OpenTUI hands the terminal.
  */
+function caretStyle(t: Harness) {
+  const find = (node: Renderable): TextareaRenderable | undefined => {
+    if (node instanceof TextareaRenderable) return node
+    for (const child of node.getChildren()) {
+      const found = find(child)
+      if (found) return found
+    }
+    return undefined
+  }
+  return find(t.renderer.root)?.cursorStyle.style
+}
+
+/** What the settings row says, which is the only place the vim rule is explained. */
 const cursorRow = (t: Harness) =>
   t
     .captureCharFrame()
@@ -64,6 +80,39 @@ test('a saved shape is what the row comes back showing', async () => {
   await runCommand(t, 'Settings')
   await down(t, CURSOR_ROW)
   expect(cursorRow(t).endsWith('line')).toBe(true)
+})
+
+test('the shape the setting names is the one the editor draws', async () => {
+  const t = await launch(fixture(PROJECT), { cursorStyle: 'underline' })
+  await openFile(t, 'a.ts')
+  expect(caretStyle(t)).toBe('underline')
+})
+
+test('vim takes the caret over, and gives it back in the shape the setting names', async () => {
+  const t = await launch(fixture(PROJECT), { vim: true, cursorStyle: 'line' })
+  await openFile(t, 'a.ts')
+  expect(caretStyle(t)).toBe('block')
+
+  await runCommand(t, 'Settings')
+  await down(t, 5) // Vim mode
+  await press(t, i => i.pressEnter())
+  await pressEscape(t)
+  expect(caretStyle(t)).toBe('line')
+})
+
+test('editing the setting while vim sits in insert mode leaves the insert caret alone', async () => {
+  const t = await launch(fixture(PROJECT), { vim: true })
+  await openFile(t, 'a.ts')
+  await press(t, i => i.pressKey('i'))
+  expect(caretStyle(t)).toBe('line')
+
+  await runCommand(t, 'Settings')
+  await down(t, CURSOR_ROW)
+  await press(t, i => i.pressArrow('right'))
+  await pressEscape(t)
+  // The mode never changed, so neither may the caret: the shape is what says which
+  // mode you are in, and nothing puts it back until the next mode swap.
+  expect(caretStyle(t)).toBe('line')
 })
 
 test('vim mode says on the row that it has taken the caret over', async () => {

--- a/test/project-settings.test.tsx
+++ b/test/project-settings.test.tsx
@@ -46,7 +46,7 @@ test('the project file outranks the user settings', async () => {
 test('a key the project leaves out keeps the user value', async () => {
   const t = await launch(project({ vim: true }), { tabSize: 8 })
   await runCommand(t, 'Settings: this project')
-  await down(t, 6) // Theme, Follow OS, Light, Dark, Transparent, Vim → Tab size
+  await down(t, 7) // Theme, Follow OS, Light, Dark, Transparent, Vim, Cursor → Tab size
   expect(rowOf(t, 'Vim mode').endsWith('on')).toBe(true)
   // Not 2: an absent key falls through to the user's file, not to the default.
   expect(rowOf(t, 'Tab size').endsWith('8')).toBe(true)
@@ -56,7 +56,7 @@ test('Tab moves the page between the two files', async () => {
   const t = await launch(project({ tabSize: 8 }))
   await runCommand(t, 'Settings')
   expect(t.captureCharFrame()).toContain('Settings — User')
-  await down(t, 6)
+  await down(t, 7)
   // The user page shows the user's own value, marked as overridden — VS Code's
   // arrangement, and the only one where stepping the row does something visible.
   expect(rowOf(t, 'Tab size').endsWith('2')).toBe(true)
@@ -81,7 +81,7 @@ test('Backspace drops an override and the user value comes back', async () => {
   const dir = project({ tabSize: 8 })
   const t = await launch(dir)
   await runCommand(t, 'Settings: this project')
-  await down(t, 6)
+  await down(t, 7)
   expect(rowOf(t, 'Tab size').endsWith('8')).toBe(true)
   await press(t, i => i.pressBackspace())
   expect(rowOf(t, 'Tab size').endsWith('2')).toBe(true)

--- a/test/settings-view.test.tsx
+++ b/test/settings-view.test.tsx
@@ -51,7 +51,7 @@ test('Enter flips a boolean, the row and the config file follow', async () => {
 test('arrows cycle a multi-value setting in both directions', async () => {
   const t = await launch(fixture(PROJECT))
   await runCommand(t, 'Settings')
-  await down(t, 6) // Tab size
+  await down(t, 7) // Tab size
   const size = () =>
     t
       .captureCharFrame()


### PR DESCRIPTION
Closes #30, where the design question behind this is written up.

Adds a `cursorStyle` config key — `block` (the default, unchanged) / `line` / `underline` — with a row on the settings page under Editor.

OpenTUI already had all of this: `CursorStyle` is `"block" | "line" | "underline" | "default"` and `cursorStyle` is an `EditBufferOptions` prop, so `<textarea>` takes it the same way it already takes `cursorColor`. Nothing upstream, no new dependency.

## Vim keeps the caret

This is the one real decision, and #30 has the longer version. `EditorPane` sets the shape imperatively on every vim mode change — `line` for insert, `block` otherwise — because the shape is how you tell the mode. Rather than have the setting fight that, **vim wins outright while it is on**:

```tsx
cursorStyle={{ style: props.vim ? 'block' : props.cursorStyle, blinking: true }}
```

`props.vim` is reactive, so this is also what puts the user's own shape back when vim is switched off — vim otherwise leaves the caret in whatever shape its last mode chose. And because it resolves to `block` while vim is on, it never clobbers the mode swap in the keyboard handler.

The setting stays editable and stays saved while vim is on; it just isn't in force. The row says so — `line (vim overrides)` — because the status line is gone by the time anyone wonders why the caret didn't change.

I left `default`, OpenTUI's fourth shape, out of the list: it defers to whatever the terminal was already set to, which isn't a value this row could meaningfully display. Easy to add if you want it.

## Nothing changes for anyone who doesn't set it

`DEFAULTS.cursorStyle` is `'block'` and `blinking: true` — byte-for-byte OpenTUI's own default (`EditBufferRenderable.d.ts`: `cursorStyle: { style: "block"; blinking: true }`). The option object replaces all fields rather than merging, so `blinking` is restated rather than dropped. An existing config with no `cursorStyle` key draws exactly the caret it drew before.

## Four test counts moved

Heads up, since it's the least interesting part of the diff and the easiest to misread: four assertions reach Tab size by counting arrow presses (`down(t, 6)`), and a new row in the Editor section shifts them to 7. `settings-view.test.tsx:193` already has a comment on a *different* test explaining this exact brittleness and searching by content instead — converting the rest felt like it belonged in its own change rather than buried here.

## Tests

New `test/cursor-style.test.tsx`, 5 tests:

- defaults to block
- arrows cycle both directions and wrap, and the value persists to the config file
- a saved shape is what the row comes back showing
- vim mode annotates the row as overridden
- the shape is still editable and still written while vim holds the caret

Worth saying plainly: the caret's shape is a terminal property, not a glyph, so `captureCharFrame()` can't see it — these assert on the row and on the file the row writes, not on a rendered caret. I didn't find a way to assert the real shape through the harness; if there's one I missed, happy to add it.

`bun run check` is green — types, lint (exit 0, no new findings in changed files), format, and the full suite.
