### PR TITLE
feat(languages): Terraform and HCL syntax highlighting

### DIFF
--- a/src/languages/highlight.ts
+++ b/src/languages/highlight.ts
@@ -105,6 +105,10 @@ export function filetypeForPath(path: string): string | undefined {
   if (DOTENV.test(name)) return 'dotenv'
   if (name.endsWith('.tsrx')) return 'tsrx'
   if (name.endsWith('.liquid')) return 'liquid'
+  // OpenTUI resolves none of these, so unlike yaml or sql the extension has to be
+  // claimed here or the patterns never run and a `.tf` renders as plain text.
+  if (name.endsWith('.tf') || name.endsWith('.tfvars')) return 'terraform'
+  if (name.endsWith('.hcl')) return 'hcl'
   return pathToFiletype(path) ?? undefined
 }
 

--- a/src/languages/index.ts
+++ b/src/languages/index.ts
@@ -40,6 +40,52 @@ export interface Language {
   patterns?: { group: string; re: RegExp }[]
 }
 
+/**
+ * HCL, which Terraform and `.hcl` files share — no grammar for it ships in
+ * `tree-sitter-wasms`, so this is patterns like yaml and sql.
+ *
+ * Order is the whole design here, since later entries win the characters they
+ * overlap:
+ *
+ * - `string` comes before `variable`, so a reference inside an interpolation
+ *   (`"${var.name}"`) still paints as one instead of disappearing into the string.
+ *   The prefixes are anchored with a `(?<![\w/.])` guard for the same reason in
+ *   reverse: without it `"https://x.dev/path.html"` paints `path.html` as a variable.
+ * - `comment` is last, so a commented-out attribute is grey all the way across
+ *   rather than keeping the colours of the code inside it. The cost is a `#` that
+ *   follows a space *inside* a string — `"a # b"` — being read as a comment; the
+ *   leading `[ \t]` guard is what keeps `"#ffffff"` and `.../#anchor` out of it,
+ *   which are the two that actually turn up. yaml and ini make the same trade.
+ *
+ * Attribute keys are line-anchored, as ini's are. `terraform fmt` puts one
+ * attribute per line, so the case that would need more is the formatted-by-hand one.
+ */
+const HCL_PATTERNS: NonNullable<Language['patterns']> = [
+  { group: 'punctuation.bracket', re: /[{}[\]()]/g },
+  { group: 'punctuation', re: /[,.:]/g },
+  { group: 'operator', re: /=>|[=!<>]=|&&|\|\||[=<>+\-*/%!?:]/g },
+  { group: 'number', re: /\b\d+(?:\.\d+)?\b/g },
+  { group: 'boolean', re: /\b(?:true|false|null)\b/g },
+  { group: 'type', re: /\b(?:string|number|bool|any|list|map|set|object|tuple)\b/g },
+  {
+    group: 'keyword',
+    re: /\b(?:resource|variable|output|module|provider|data|locals|terraform|backend|provisioner|connection|lifecycle|dynamic|moved|import|check|removed|depends_on|for|in|if|else)\b/g,
+  },
+  { group: 'property', re: /^[ \t]*[\w-]+(?=[ \t]*=(?!=))/gm },
+  { group: 'function', re: /\b[a-z_]\w*(?=\()/g },
+  { group: 'string', re: /"(?:[^"\\\n]|\\.)*"/g },
+  // Heredocs, whose terminator is whatever the `<<` named — hence the backreference.
+  { group: 'string', re: /<<[-~]?(\w+)[\s\S]*?^[ \t]*\1\b/gm },
+  {
+    group: 'variable',
+    re: /(?<![\w/.])(?:var|local|data|module|each|count|path|self|terraform)(?:\.\w+)+/g,
+  },
+  // Only the openers: the closing brace is a brace, and painting every `}` as an
+  // interpolation would take every block's closing line with it.
+  { group: 'punctuation.special', re: /\$\{|%\{/g },
+  { group: 'comment', re: /(?:^|[ \t])(?:#|\/\/).*|\/\*[\s\S]*?\*\//gm },
+]
+
 export const LANGUAGES: Language[] = [
   { id: 'javascript', label: 'js', bundled: true },
   { id: 'typescript', label: 'ts', bundled: true },
@@ -151,6 +197,11 @@ export const LANGUAGES: Language[] = [
       { group: 'comment', re: /--.*$|\/\*[\s\S]*?\*\//gm },
     ],
   },
+  // Two ids over one set of patterns, as css/scss/sass are over one grammar: the
+  // syntax is HCL either way, and the status bar saying "terraform" over a `.tf`
+  // and "hcl" over a Packer or Nomad file is the only difference between them.
+  { id: 'terraform', label: 'tf', patterns: HCL_PATTERNS },
+  { id: 'hcl', patterns: HCL_PATTERNS },
   {
     id: 'ini',
     patterns: [

--- a/test/languages.test.ts
+++ b/test/languages.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, test } from 'bun:test'
 
 import { LANGUAGES, languageFor, languageLabel } from '../src/languages'
-import { computeHighlights, getSyntaxStyle, segmentsIn, STALE } from '../src/languages/highlight'
+import {
+  computeHighlights,
+  filetypeForPath,
+  getSyntaxStyle,
+  segmentsIn,
+  STALE,
+} from '../src/languages/highlight'
 import type { Highlighted, Segment } from '../src/languages/highlight'
 import { allSegments, parseHighlights, WHOLE } from './syntax'
 
@@ -35,6 +41,8 @@ const SAMPLES: Record<string, string> = {
   sql: '-- c\nSELECT id FROM users WHERE age > 18;\n',
   ini: '; c\n[section]\nkey = value\n',
   dotenv: '# c\nexport PORT=3000\nURL="https://x.dev"\n',
+  terraform: '# c\nresource "aws_instance" "web" {\n  ami = var.ami_id\n}\n',
+  hcl: '# c\njob "web" {\n  type = "service"\n}\n',
 }
 
 describe('languages', () => {
@@ -311,4 +319,92 @@ describe('segmenting a window instead of the document', () => {
     }
     expect(stitched.toSorted()).toEqual(whole)
   }, 20000)
+})
+
+// The `${var...}` below is Terraform interpolation, not a template literal.
+/* oxlint-disable no-template-curly-in-string */
+describe('terraform', () => {
+  const SOURCE = [
+    'terraform {',
+    '  required_version = ">= 1.0"',
+    '}',
+    '',
+    '# a commented-out attribute',
+    '# ami = "abc"',
+    '',
+    'variable "prefix" {',
+    '  type    = string',
+    '  default = null',
+    '}',
+    '',
+    'resource "aws_instance" "web" {',
+    '  instance_type = "t3.micro"',
+    '  count         = var.enabled ? 1 : 0',
+    '  colour        = "#ffffff"',
+    '  docs          = "https://x.dev/path.html#anchor"',
+    '  name          = "${var.prefix}-web" // trailing',
+    '  tags          = merge(local.common, {})',
+    '}',
+    '',
+  ].join('\n')
+
+  const styleAt = styleLookup(SOURCE)
+  const segsFor = () => allSegments(SOURCE, 'terraform')
+
+  test('block heads, keys, types, values and calls each take their own colour', async () => {
+    const segs = await segsFor()
+    expect(isStyle(styleAt(segs, 'resource'), 'keyword')).toBe(true)
+    expect(isStyle(styleAt(segs, 'variable'), 'keyword')).toBe(true)
+    expect(isStyle(styleAt(segs, 'instance_type'), 'property')).toBe(true)
+    expect(isStyle(styleAt(segs, 'string'), 'type')).toBe(true)
+    expect(isStyle(styleAt(segs, 'null'), 'boolean')).toBe(true)
+    expect(isStyle(styleAt(segs, '"t3.micro"'), 'string')).toBe(true)
+    expect(isStyle(styleAt(segs, 'merge('), 'function')).toBe(true)
+  })
+
+  test('a reference inside an interpolation survives the string around it', async () => {
+    const segs = await segsFor()
+    // The whole point of `string` painting before `variable`.
+    expect(isStyle(styleAt(segs, 'var.prefix'), 'variable')).toBe(true)
+    // Its own theme entry, not the `punctuation` fallback — the closing brace a
+    // line below is the one that lands on plain punctuation.
+    expect(isStyle(styleAt(segs, '${'), 'punctuation.special')).toBe(true)
+    expect(isStyle(styleAt(segs, 'local.common'), 'variable')).toBe(true)
+    expect(isStyle(styleAt(segs, 'var.enabled'), 'variable')).toBe(true)
+  })
+
+  test('a # that is not a comment is left alone', async () => {
+    const segs = await segsFor()
+    // Both are `#` inside a string, and both are why the comment pattern insists
+    // on a leading space or tab rather than matching a bare `#`.
+    expect(isStyle(styleAt(segs, '"#ffffff"'), 'string')).toBe(true)
+    expect(isStyle(styleAt(segs, '#anchor'), 'string')).toBe(true)
+  })
+
+  test('comments win the line, including one that comments out code', async () => {
+    const segs = await segsFor()
+    // `ami` and its string would otherwise keep property and string colours.
+    expect(isStyle(styleAt(segs, 'ami ='), 'comment')).toBe(true)
+    expect(isStyle(styleAt(segs, '"abc"'), 'comment')).toBe(true)
+    expect(isStyle(styleAt(segs, '// trailing'), 'comment')).toBe(true)
+  })
+
+  test('the extensions route to a filetype at all', () => {
+    // OpenTUI resolves none of these, so without the lines in `filetypeForPath`
+    // every assertion above would still pass and a real `.tf` would render plain.
+    expect(filetypeForPath('main.tf')).toBe('terraform')
+    expect(filetypeForPath('infra/prod.tfvars')).toBe('terraform')
+    expect(filetypeForPath('terraform.tfvars')).toBe('terraform')
+    expect(filetypeForPath('packer.hcl')).toBe('hcl')
+    // Not swept up by a suffix that merely ends in the same letters.
+    expect(filetypeForPath('shelf.ts')).toBe('typescript')
+  })
+
+  test('hcl paints the same, under its own name', async () => {
+    const segs = await allSegments('# c\njob "web" {\n  type = "service"\n}\n', 'hcl')
+    const styles = styleLookup('# c\njob "web" {\n  type = "service"\n}\n')
+    expect(isStyle(styles(segs, '"service"'), 'string')).toBe(true)
+    expect(languageFor('hcl')).toBeDefined()
+    expect(languageLabel('terraform')).toBe('tf')
+  })
 })


### PR DESCRIPTION
`.tf`, `.tfvars` and `.hcl` currently render as plain text — not partially highlighted, but with no colour at all. Two things have to be true for a language to paint, and neither was:

- **No grammar exists to use.** `tree-sitter-wasms` ships 35 grammars and none of them is HCL, so the tree-sitter route would mean sourcing and vendoring one from outside the package.
- **Nothing claims the extensions.** `pathToFiletype` answers `undefined` for all three:

  ```
  main.tf      -> undefined      a.ts    -> typescript
  vars.tfvars  -> undefined      a.yaml  -> yaml
  a.hcl        -> undefined      a.sql   -> sql
  ```

So this goes the patterns route, the one `index.ts` already describes as "the whole answer for a format with no usable grammar" — same as yaml, sql and ini. No wasm, no new dependency, nothing added to the build.

## Order is the design

Later patterns win the characters they overlap, so the sequence is the whole of it. Three decisions worth pointing at, because each looks arbitrary until it isn't:

- **`string` paints before `variable`**, so a reference inside an interpolation survives the string wrapped around it — `"${var.prefix}-web"` keeps `var.prefix` as a variable instead of losing it to the string.
- **The reference prefixes carry a `(?<![\w/.])` guard.** Without it, `"https://x.dev/path.html"` paints `path.html` as a variable, because `path.` is one of Terraform's own prefixes.
- **`comment` is last**, so a commented-out attribute goes grey the whole way across rather than keeping the property and string colours underneath it. The cost is a `#` that follows a space *inside* a string being read as a comment; the leading `[ \t]` on the rule is what keeps `"#ffffff"` and `.../#anchor` — the two that actually turn up — out of it. yaml and ini make the same trade.

Attribute keys are line-anchored, as ini's are. `terraform fmt` puts one attribute per line, so the case that would want more is the hand-formatted one.

## Two ids, one pattern set

`terraform` (`.tf`, `.tfvars`) and `hcl` (`.hcl`) share `HCL_PATTERNS`, the way css/scss/sass share one grammar. The syntax is HCL either way; the only difference is the status bar saying `tf` over a Terraform file and `hcl` over a Packer or Nomad one.

Sharing the RegExp objects between the two entries is safe — `highlightWithPatterns` goes through `content.matchAll(re)`, which clones the regex rather than advancing the original's `lastIndex`.

## The `filetypeForPath` lines are load-bearing

Worth calling out because it's the part that would be dropped as redundant in review: unlike yaml or sql, OpenTUI resolves none of these extensions, so **without those two lines the patterns never run and a `.tf` still renders plain** — while every painting test above would still pass. There's a separate test for the routing for exactly that reason.

## Tests

Six, in `test/languages.test.ts`, next to the liquid ones:

- block heads, keys, types, values and calls each take their own colour
- a reference inside an interpolation survives the string around it
- a `#` that is not a comment is left alone (`"#ffffff"`, `.../#anchor`)
- comments win the line, including one that comments out code
- the extensions route to a filetype at all
- hcl paints the same, under its own name

Plus `terraform` and `hcl` entries in `SAMPLES`, which the existing per-language loop picks up.

One of these caught a wrong assumption of mine while writing it: I expected `${` to fall back to `punctuation`, and it has its own theme entry (`punctuation.special`). The test asserts the real one.

## On the suite

`bun run check` is green on types, lint and format. `test/tree-focus.test.tsx` failed in my
run, and **it is a flake on this machine, not something from this change** — it fails the
same way on `main` with this branch stashed, and on a fresh clone of `main`.

I originally wrote this section up as a consistent failure. That was wrong and I would
rather correct it than leave it: over enough runs it passes and fails on the *same*
commit — including the base this branch was cut from. It seems to pass when run cold and
fail under repeated back-to-back runs, which fits the loaded-run flakiness `5cc0807`
already went after. My "it is not a race, it survives 2.5s of settling" reasoning was also
wrong: the reveal is one-shot, so settling after it has already been missed cannot undo it
and proves nothing either way.

Nothing here needs action from you — I am noting it only so a failure in this file, if you
see one, is not read as coming from this PR. This change touches language definitions
alone.

Everything else — 120 of 121 files — passes, `languages.test.ts` among them at 58 tests.
