### PR TITLE
feat(cli): apply the column from file.ts:42:7

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ druk                  # the current directory
 druk ./my-app         # a directory
 druk src/main.ts      # a single file
 druk src/main.ts:42   # …opened at line 42
+druk src/main.ts:42:7 # …at line 42, column 7
 ```
 
 `npx druk` and `bunx druk` work without installing anything.

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -68,6 +68,8 @@ export function App(props: {
   openFile?: string | null
   /** `druk file.ts:42`: 0-based line to land on in `openFile`. */
   openLine?: number | null
+  /** `druk file.ts:42:7`: 0-based column to land on, beside `openLine`. */
+  openCol?: number | null
   /** The user's own settings; the project's overrides go on top of them. */
   initialConfig: Config
   /**
@@ -296,8 +298,9 @@ export function App(props: {
     const line = props.openLine
     const buffer = workspace.activeBuffer()
     if (line != null && buffer) {
-      const total = buffer.content.split('\n').length
-      editor.requestGoto(Math.min(line, total - 1), 0)
+      const lines = buffer.content.split('\n')
+      const row = Math.min(line, lines.length - 1)
+      editor.requestGoto(row, Math.min(props.openCol ?? 0, lines[row]!.length))
     }
   })
 

--- a/src/core/cli.ts
+++ b/src/core/cli.ts
@@ -30,6 +30,8 @@ export interface Target {
   openFile: string | null
   /** 0-based line from `druk file.ts:42`; null when none was asked for. */
   line: number | null
+  /** 0-based column from `druk file.ts:42:7`; null when none was asked for. */
+  col: number | null
 }
 
 /**
@@ -47,16 +49,21 @@ export interface Target {
 export function resolveTarget(arg: string | undefined, cwd: string): Target | null {
   const target = resolve(cwd, arg ?? '.')
   if (exists(target)) {
-    if (isDirectory(target)) return { rootDir: target, openFile: null, line: null }
-    return { rootDir: dirname(target), openFile: target, line: null }
+    if (isDirectory(target)) return { rootDir: target, openFile: null, line: null, col: null }
+    return { rootDir: dirname(target), openFile: target, line: null, col: null }
   }
 
   // Lazy, so `file.ts:42:7` reads as line 42 column 7, not a file named `file.ts:42`.
-  const at = /^(.+?):(\d+)(?::\d+)?$/.exec(arg ?? '')
+  const at = /^(.+?):(\d+)(?::(\d+))?$/.exec(arg ?? '')
   if (at) {
     const file = resolve(cwd, at[1]!)
     if (exists(file) && !isDirectory(file)) {
-      return { rootDir: dirname(file), openFile: file, line: Math.max(0, Number(at[2]) - 1) }
+      return {
+        rootDir: dirname(file),
+        openFile: file,
+        line: Math.max(0, Number(at[2]) - 1),
+        col: at[3] ? Math.max(0, Number(at[3]) - 1) : null,
+      }
     }
   }
   return null

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -40,6 +40,7 @@ export async function main(target: Target): Promise<void> {
         rootDir={rootDir}
         openFile={openFile}
         openLine={target.line}
+        openCol={target.col}
         initialConfig={config}
         initialProject={project}
       />

--- a/test/helpers.tsx
+++ b/test/helpers.tsx
@@ -39,7 +39,7 @@ export async function launch(
   /** Terminal size, for anything that has to degrade on a small screen. */
   size: { width?: number; height?: number } = {},
   /** `openFile` renders single-file mode, as `druk <file>` does. */
-  options: { openFile?: string; openLine?: number; checkUpdates?: boolean } = {},
+  options: { openFile?: string; openLine?: number; openCol?: number; checkUpdates?: boolean } = {},
 ) {
   const t = await testRender(
     () =>
@@ -47,6 +47,7 @@ export async function launch(
         rootDir: dir,
         openFile: options.openFile ?? null,
         openLine: options.openLine ?? null,
+        openCol: options.openCol ?? null,
         // LSP is off unless a test opts in: the default would spawn whatever
         // real language server the machine has on PATH, per launch. The install
         // offer is off for a sharper reason — it is a modal, so on a machine

--- a/test/single-file.test.tsx
+++ b/test/single-file.test.tsx
@@ -146,7 +146,7 @@ describe('the CLI itself', () => {
 describe('resolveTarget', () => {
   test('a directory is the project, with no file to open', () => {
     const dir = fixture(PROJECT)
-    expect(resolveTarget(dir, '/')).toEqual({ rootDir: dir, openFile: null, line: null })
+    expect(resolveTarget(dir, '/')).toEqual({ rootDir: dir, openFile: null, line: null, col: null })
   })
 
   test('a file opens alone, rooted at the folder holding it', () => {
@@ -155,6 +155,7 @@ describe('resolveTarget', () => {
       rootDir: join(dir, 'src'),
       openFile: join(dir, 'src/deep.ts'),
       line: null,
+      col: null,
     })
   })
 
@@ -164,12 +165,18 @@ describe('resolveTarget', () => {
       rootDir: dir,
       openFile: join(dir, 'two.ts'),
       line: null,
+      col: null,
     })
   })
 
   test('no argument at all means the working directory', () => {
     const dir = fixture(PROJECT)
-    expect(resolveTarget(undefined, dir)).toEqual({ rootDir: dir, openFile: null, line: null })
+    expect(resolveTarget(undefined, dir)).toEqual({
+      rootDir: dir,
+      openFile: null,
+      line: null,
+      col: null,
+    })
   })
 
   test('a path that is not there is refused rather than guessed at', () => {
@@ -184,9 +191,11 @@ describe('resolveTarget', () => {
       rootDir: dir,
       openFile: join(dir, 'two.ts'),
       line: 41,
+      col: null,
     })
-    // A column suffix is tolerated and ignored.
-    expect(resolveTarget('two.ts:42:7', dir)?.line).toBe(41)
+    // Both numbers are 0-based in the result; the CLI form is 1-based.
+    expect(resolveTarget('two.ts:42:7', dir)).toMatchObject({ line: 41, col: 6 })
+    expect(resolveTarget('two.ts:42:0', dir)?.col).toBe(0)
     // But a missing file is still a missing file.
     expect(resolveTarget('nope.ts:42', dir)).toBeNull()
   })
@@ -197,6 +206,7 @@ describe('resolveTarget', () => {
       rootDir: dir,
       openFile: join(dir, 'odd.ts:1'),
       line: null,
+      col: null,
     })
   })
 })
@@ -207,4 +217,19 @@ test('opening at a line puts the cursor there', async () => {
   const t = await launch(dir, {}, {}, { openFile: join(dir, 'big.ts'), openLine: 41 })
 
   expect(t.captureCharFrame()).toContain('Ln 42, Col 1')
+})
+
+test('opening at a line and column puts the cursor on both', async () => {
+  const lines = Array.from({ length: 60 }, (_, i) => `const v${i} = ${i}`).join('\n')
+  const dir = fixture({ 'big.ts': `${lines}\n` })
+  const t = await launch(dir, {}, {}, { openFile: join(dir, 'big.ts'), openLine: 41, openCol: 6 })
+
+  expect(t.captureCharFrame()).toContain('Ln 42, Col 7')
+})
+
+test('a column past the end of the line stops at the end', async () => {
+  const dir = fixture({ 'a.ts': 'const a = 1\n' })
+  const t = await launch(dir, {}, {}, { openFile: join(dir, 'a.ts'), openLine: 0, openCol: 999 })
+
+  expect(t.captureCharFrame()).toContain('Ln 1, Col 12')
 })


### PR DESCRIPTION
`druk file.ts:42:7` already parses — the target regex takes an optional column — but the column was dropped on the floor: `Target` only carried `line`, and the app always landed the cursor at column 0. This is item P0.2 (§1.2) on IMPROVEMENTS.md, "`file.ts:42:7` column still ignored."

This threads the column through the same path the line takes: `resolveTarget` captures it (0-based in `Target`, 1-based on the CLI, same conversion as the line), `main.tsx` passes it beside `openLine`, and the mount hook clamps it to the target line's length the way it already clamps the line to the buffer.

Which strings are accepted doesn't change — the optional group was already in the regex, so a file literally named `file.ts:42` still wins over the line reading, and `file.ts:42` alone still lands at the start of the line.

Tests: the `resolveTarget` cases now pin the column (including `:42:0` and the colon-named-file precedence), and two new frame tests assert `Ln 42, Col 7` and that a column past the end of the line stops at the end. README's open-a-project block shows the form. `bun run check` is green.
