### PR TITLE
feat(editor): a word wrap toggle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,9 @@ Tab or every file at once with Shift+Tab, which turns the results into a list of
 command palette,
 themes, vim mode, a caret shape (`cursorStyle` — block, line or underline, which vim mode
 overrides while it is on, since there the shape is what tells normal from insert),
+word wrap on by default with a toggle (`wrap`, palette → View → Toggle word wrap —
+off, a long line's tail is reached by moving the cursor into it, since OpenTUI
+scrolls sideways only with the caret),
 git marks in tree/gutter/status bar plus a source-control panel in the sidebar
 (changed files as a folder tree or a flat list — `gitPanelView` — folders folding on
 → / ←, or all of them from the header's `▴`) and palette commands for commit/undo/stash/push/fetch/pull — a push origin

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ instead of breaking startup.
 | `iconTheme` | `"none"` | file icons in the tree: `unicode` (shapes any font has), or a set from the market — `nerd-icons` needs a patched font |
 | `tabSize` | `2` | 1–16 |
 | `cursorStyle` | `"block"` | `block`, `line` or `underline` — the caret's shape, which vim mode overrides while it is on, since there the shape is what tells normal from insert |
+| `wrap` | `true` | set `false` to keep each line on one row — the tail of a long line is then reached by moving the cursor into it (palette → View → Toggle word wrap) |
 | `vim` | `false` | normal / insert / visual modes, `hjkl w b 0 $ gg G`, counts, `i a o`, `x dd dw cw`, `v` + `d y c`, `yy p P`, `u` / `Ctrl+R` |
 | `sidebarWidth` | `"auto"` | a quarter of the window, or pin 15–80 columns |
 | `trimOnSave` | `false` | on save: strip trailing spaces and end the file with one newline |

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -572,6 +572,7 @@ export function App(props: {
             lineOp={editor.lineOp()}
             vim={config.vim}
             cursorStyle={config.cursorStyle}
+            wrap={config.wrap}
             tabSize={config.tabSize}
             gitLines={git.gitLines()}
             problems={problemLines()}

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -244,6 +244,7 @@ export function createCommands(ctx: AppContext) {
     setTheme: settings.applyTheme,
     previewTheme: settings.previewTheme,
     restoreTheme: settings.restoreTheme,
+    toggleWrap: settings.toggleWrap,
     lineOp: editor.requestLineOp,
     triggerCompletion: editor.requestCompletion,
     openSettings: () => {

--- a/src/app/commands.ts
+++ b/src/app/commands.ts
@@ -58,6 +58,7 @@ export interface CommandActions {
   collapseSidebar: () => void
   toggleGitView: () => void
   toggleMarkdown: () => void
+  toggleWrap: () => void
   setTheme: (name: ThemeName) => void
   previewTheme: (name: ThemeName) => void
   restoreTheme: () => void
@@ -276,6 +277,11 @@ export function buildCommands(actions: CommandActions, ctx: CommandContext): Com
           label: 'Markdown: rendered / source',
           hint: `Ctrl+${ALT}+M`,
           run: actions.toggleMarkdown,
+        },
+        {
+          id: 'view.wrap',
+          label: 'Toggle word wrap',
+          run: actions.toggleWrap,
         },
         {
           id: 'view.focus',

--- a/src/app/keyboard.ts
+++ b/src/app/keyboard.ts
@@ -53,6 +53,7 @@ export function installKeyboard(ctx: AppContext, actions: CommandActions) {
     'view.git': panes.toggleGitView,
     'view.collapse': actions.collapseSidebar,
     'view.markdown': workspace.toggleRendered,
+    'view.wrap': actions.toggleWrap,
     'view.focus': actions.toggleFocus,
     'git.diffFile': actions.gitDiffFile,
     'git.commit': actions.gitCommit,

--- a/src/app/keymap.ts
+++ b/src/app/keymap.ts
@@ -82,6 +82,7 @@ export const BINDABLE: Bindable[] = [
     label: 'Markdown: rendered / source',
     defaults: [`Ctrl+${ALT}+M`],
   },
+  { id: 'view.wrap', label: 'Toggle word wrap', defaults: [] },
   { id: 'view.focus', label: 'Focus tree / editor', defaults: [] },
   { id: 'git.diffFile', label: 'Diff current file', defaults: [] },
   { id: 'git.commit', label: 'Commit…', defaults: [] },

--- a/src/app/settings.ts
+++ b/src/app/settings.ts
@@ -196,6 +196,11 @@ export function createSettings(deps: {
     status.say(`Transparent background ${onOff(config.transparent)}`)
   }
 
+  const toggleWrap = () => {
+    patchConfig({ wrap: !view().wrap })
+    status.say(`Word wrap ${onOff(config.wrap)}`)
+  }
+
   const applyIconTheme = (id: string) => {
     patchConfig({ iconTheme: id })
     status.say(
@@ -656,6 +661,13 @@ export function createSettings(deps: {
     },
     {
       section: 'Editor',
+      key: 'wrap',
+      label: 'Word wrap',
+      value: onOff(view().wrap),
+      cycle: toggleWrap,
+    },
+    {
+      section: 'Editor',
       key: 'tabSize',
       label: 'Tab size',
       value: String(view().tabSize),
@@ -887,6 +899,7 @@ export function createSettings(deps: {
     restoreTheme,
     toggleThemeSync,
     toggleTransparent,
+    toggleWrap,
     applyTabSize,
     applyVim,
     toggleTrim,

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -100,6 +100,12 @@ export interface Config {
    */
   cursorStyle: CursorStyle
   /**
+   * Soft-wrap long lines at the window's edge. Off, a line past the edge is read
+   * by moving the caret into it — OpenTUI scrolls the view sideways only with
+   * the cursor, which is the trade for one buffer line per screen row.
+   */
+  wrap: boolean
+  /**
    * Columns per indent level for space indentation — the Tab key and the guides.
    * A literal tab is two columns whatever this says: OpenTUI's renderer fixes that
    * width and exposes no setting for it.
@@ -199,6 +205,8 @@ export const DEFAULTS: Config = {
   vim: false,
   // OpenTUI's own default, so an unset key keeps the caret druk has always drawn.
   cursorStyle: 'block',
+  // On, because it always was: druk wrapped unconditionally before this was a key.
+  wrap: true,
   tabSize: 2,
   sidebarWidth: 'auto',
   skipUpdate: '',
@@ -273,6 +281,7 @@ const VALIDATORS: { [K in keyof Config]: Validator<K> } = {
   iconTheme: raw => (isIconThemeName(raw) ? raw : undefined),
   vim: bool,
   cursorStyle: among(...CURSOR_STYLES),
+  wrap: bool,
   tabSize: raw => (typeof raw === 'number' && raw >= 1 && raw <= 16 ? Math.floor(raw) : undefined),
   sidebarWidth: raw => {
     if (raw === 'auto') return 'auto'

--- a/src/ui/EditorPane.tsx
+++ b/src/ui/EditorPane.tsx
@@ -63,6 +63,8 @@ export interface EditorPaneProps {
   vim: boolean
   /** Caret shape, for as long as vim is off — see the `cursorStyle` config key. */
   cursorStyle: CursorStyle
+  /** Soft-wrap long lines — see the `wrap` config key. */
+  wrap: boolean
   tabSize: number
   /** True while a modal owns the keyboard; the editor must ignore all keys. */
   blocked: boolean
@@ -1502,10 +1504,11 @@ export function EditorPane(props: EditorPaneProps) {
                 style: props.vim ? (vimMode() === 'insert' ? 'line' : 'block') : props.cursorStyle,
                 blinking: true,
               }}
-              // Always wrapping: OpenTUI's textarea scrolls sideways only by
-              // dragging the caret along, so unwrapped long lines have no way to be
-              // read that does not move the cursor.
-              wrapMode="word"
+              // Wrapped by default: OpenTUI's textarea scrolls sideways only by
+              // dragging the caret along, so with `wrap` off a long line's tail is
+              // reached by moving the cursor into it — the trade that setting makes
+              // for one buffer line per screen row.
+              wrapMode={props.wrap ? 'word' : 'none'}
               // OpenTUI takes a glyph, not a width: the number it accepts is a code
               // point, so passing a tab size painted control characters into the first
               // cell of every tab. A terminal drops those, leaving whatever the cell

--- a/test/project-settings.test.tsx
+++ b/test/project-settings.test.tsx
@@ -49,7 +49,7 @@ test('the project file outranks the user settings', async () => {
 test('a key the project leaves out keeps the user value', async () => {
   const t = await launch(project({ vim: true }), { tabSize: 8 })
   await runCommand(t, 'Settings: this project')
-  await down(t, 8) // Theme, Follow OS, Light, Dark, Transparent, Icons, Vim, Cursor → Tab size
+  await down(t, 9) // Theme, Follow OS, Light, Dark, Transparent, Icons, Vim, Cursor, Word wrap → Tab size
   expect(rowOf(t, 'Vim mode').endsWith('on')).toBe(true)
   // Not 2: an absent key falls through to the user's file, not to the default.
   expect(rowOf(t, 'Tab size').endsWith('8')).toBe(true)
@@ -59,7 +59,7 @@ test('Tab moves the page between the two files', async () => {
   const t = await launch(project({ tabSize: 8 }))
   await runCommand(t, 'Settings')
   expect(t.captureCharFrame()).toContain('Settings — User')
-  await down(t, 8)
+  await down(t, 9)
   // The user page shows the user's own value, marked as overridden — VS Code's
   // arrangement, and the only one where stepping the row does something visible.
   expect(rowOf(t, 'Tab size').endsWith('2')).toBe(true)
@@ -84,7 +84,7 @@ test('Backspace drops an override and the user value comes back', async () => {
   const dir = project({ tabSize: 8 })
   const t = await launch(dir)
   await runCommand(t, 'Settings: this project')
-  await down(t, 8)
+  await down(t, 9)
   expect(rowOf(t, 'Tab size').endsWith('8')).toBe(true)
   await press(t, i => i.pressBackspace())
   expect(rowOf(t, 'Tab size').endsWith('2')).toBe(true)

--- a/test/settings-view.test.tsx
+++ b/test/settings-view.test.tsx
@@ -62,7 +62,7 @@ test('Enter flips a boolean, the row and the config file follow', async () => {
 test('arrows cycle a multi-value setting in both directions', async () => {
   const t = await launch(fixture(PROJECT))
   await runCommand(t, 'Settings')
-  await down(t, 8) // Tab size
+  await down(t, 9) // Tab size
   const size = () =>
     t
       .captureCharFrame()

--- a/test/wrap.test.tsx
+++ b/test/wrap.test.tsx
@@ -1,0 +1,45 @@
+import { expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { CONFIG_FILE } from '../src/core/config'
+import { fixture, launch, runCommand, settle } from './helpers'
+
+// Wide enough to open with the sidebar, narrow enough that the marker is past
+// the editor's right edge — only a wrapped continuation row can show it.
+const TAIL = 'TAIL_MARKER'
+const PROJECT = { 'a.ts': `const line = "${'x'.repeat(80)}" // ${TAIL}\n` }
+
+const SIZE = { width: 60, height: 20 }
+
+const savedWrap = () => JSON.parse(readFileSync(CONFIG_FILE, 'utf8')).wrap
+
+test('long lines wrap by default, as they always have', async () => {
+  const dir = fixture(PROJECT)
+  const t = await launch(dir, {}, SIZE, { openFile: join(dir, 'a.ts') })
+
+  expect(t.captureCharFrame()).toContain(TAIL)
+})
+
+test('wrap: false keeps one buffer line per row, tail past the edge', async () => {
+  const dir = fixture(PROJECT)
+  const t = await launch(dir, { wrap: false }, SIZE, { openFile: join(dir, 'a.ts') })
+
+  expect(t.captureCharFrame()).not.toContain(TAIL)
+})
+
+test('the palette command toggles wrap live, and it persists', async () => {
+  const dir = fixture(PROJECT)
+  const t = await launch(dir, {}, SIZE, { openFile: join(dir, 'a.ts') })
+  expect(t.captureCharFrame()).toContain(TAIL)
+
+  await runCommand(t, 'Toggle word wrap')
+  await settle(t)
+  expect(t.captureCharFrame()).not.toContain(TAIL)
+  expect(savedWrap()).toBe(false)
+
+  await runCommand(t, 'Toggle word wrap')
+  await settle(t)
+  expect(t.captureCharFrame()).toContain(TAIL)
+  expect(savedWrap()).toBe(true)
+})

--- a/test/wrap.test.tsx
+++ b/test/wrap.test.tsx
@@ -5,8 +5,8 @@ import { join } from 'node:path'
 import { CONFIG_FILE } from '../src/core/config'
 import { fixture, launch, runCommand, settle } from './helpers'
 
-// Wide enough to open with the sidebar, narrow enough that the marker is past
-// the editor's right edge — only a wrapped continuation row can show it.
+// Narrow enough that the marker sits past the editor's right edge — only a
+// wrapped continuation row can show it.
 const TAIL = 'TAIL_MARKER'
 const PROJECT = { 'a.ts': `const line = "${'x'.repeat(80)}" // ${TAIL}\n` }
 


### PR DESCRIPTION
Closes #37.

druk has always wrapped: `wrapMode="word"` was hardcoded in the editor, with a comment explaining why — OpenTUI's textarea scrolls sideways only by dragging the caret along, so unwrapped long lines had no way to be read that doesn't move the cursor. This keeps that behavior as the default (`wrap: true` — nothing changes for anyone who doesn't touch it) and adds the off switch the issue asks for: with `wrap: false` each buffer line stays on one row, and the tail of a long line is reached by moving the cursor into it — the trade the old comment named, now a choice instead of a constant.

Surface: a Word wrap row on the settings page (Editor section), palette → View → Toggle word wrap (flips and persists the setting live), and the `wrap` key in the README's settings table. The editor comment is rewritten to explain the default rather than the constant.

Tests: wrap-on default shows a long line's tail on a continuation row, `wrap: false` keeps it past the edge, and the palette command toggles the frame live and round-trips through config.json. The two settings tests that reach Tab size by row count move down one row for the new entry.
