### PR TITLE
feat(search): replace across the project, with preview and confirm

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,12 @@ file picker both skip git-ignored paths, whatever the tree's `respectGitignore` 
 a build directory or an agent's worktree checkout is never a result; the panel previews
 the selected hit in its file, syntax-coloured and with the hit picked out, over as many
 lines either side as the terminal has room for, and folds a file behind its heading with
-Tab or every file at once with Shift+Tab, which turns the results into a list of files),
+Tab or every file at once with Shift+Tab, which turns the results into a list of files;
+palette → Find → Replace in project adds a replace field to that panel — rows preview the
+hit beside its replacement, Enter applies one match, Ctrl+A applies everywhere behind a
+confirm naming true counts past the 200-row display cap, open buffers take the edit
+unsaved while closed files are written with their encoding kept, and the scan reads open
+dirty buffers instead of their disk copies so what is listed is what is replaced),
 command palette,
 themes, vim mode, a caret shape (`cursorStyle` — block, line or underline, which vim mode
 overrides while it is on, since there the shape is what tells normal from insert),

--- a/README.md
+++ b/README.md
@@ -157,6 +157,15 @@ the file you are on, so one file with forty hits stops burying the rest.
 In file search, `Tab` opens the replace field instead: `Enter` replaces the selected match,
 `Ctrl+A` replaces every match in the file.
 
+The whole project replaces too: *Find → Replace in project* in the palette opens the
+project search with the replace field showing, and every row previews the hit beside what
+would replace it. `Enter` applies the selected match; `Ctrl+A` asks first — the confirm
+names the real match and file counts, beyond the 200 rows the panel shows — then applies
+everywhere. Open files take the edit in their buffer (the tab goes unsaved, and the active
+file can undo it); closed files are written straight to disk, keeping their line endings.
+With the replace field up, `Tab` moves between the two boxes; plain project search keeps
+`Tab` for folding.
+
 `Ctrl+C`, `Ctrl+W` and `Ctrl+R` toggle case-sensitive, whole-word and regex matching
 while the search is open; the active ones are shown beside the match count.
 

--- a/src/app/Overlays.tsx
+++ b/src/app/Overlays.tsx
@@ -4,8 +4,8 @@ import { createEffect, createMemo, createSignal, Show } from 'solid-js'
 import type { Accessor } from 'solid-js'
 
 import type { Branch } from '../core/git'
-import { replaceAll, replaceMatch } from '../core/search'
-import type { Match } from '../core/search'
+import { buildQuery, planProjectReplace, replaceAll, replaceMatch } from '../core/search'
+import type { Match, SearchOptions } from '../core/search'
 import type { UpdateInfo } from '../core/update'
 import { BranchPicker } from '../ui/BranchPicker'
 import { ChoiceModal } from '../ui/ChoiceModal'
@@ -18,7 +18,7 @@ import { FilePicker } from '../ui/FilePicker'
 import { HelpOverlay } from '../ui/HelpOverlay'
 import { KeyPeek } from '../ui/KeyPeek'
 import { PromptModal } from '../ui/PromptModal'
-import { SearchPanel } from '../ui/SearchPanel'
+import { MIN_QUERY, SearchPanel } from '../ui/SearchPanel'
 import type { SearchScope } from '../ui/SearchPanel'
 import { UpdateBanner } from '../ui/UpdateBanner'
 import type { Branches } from './branches'
@@ -31,6 +31,16 @@ import type { Panes } from './panes'
 import type { PromptState } from './prompts'
 import type { Confirmation, Conflict } from './types'
 import type { Workspace } from './workspace'
+
+/** The active search toggles, named in the confirm so what runs is what was agreed to. */
+const searchFlags = (options: SearchOptions) => {
+  const parts = [
+    options.caseSensitive && 'case',
+    options.wholeWord && 'word',
+    options.regex && 'regex',
+  ].filter(Boolean)
+  return parts.length > 0 ? ` (${parts.join(', ')})` : ''
+}
 
 /** The transient full-screen surfaces: search, pickers, palette, help, update. */
 export function createOverlays(deps: {
@@ -185,7 +195,13 @@ export function OverlayStack(props: { ctx: AppContext; commands: Accessor<Comman
             verb={ask().verb}
             danger={ask().danger}
             message={ask().message}
-            onConfirm={prompts.confirmPrompt}
+            onConfirm={() => {
+              const confirmed = prompts.prompt()
+              prompts.confirmPrompt()
+              // The panel sat suspended under the modal so cancel could return to
+              // it; a confirmed replace is the one outcome that is done with it.
+              if (confirmed?.kind === 'replaceProject') overlays.setSearch(null)
+            }}
             onCancel={prompts.cancelPrompt}
           />
         )}
@@ -199,6 +215,8 @@ export function OverlayStack(props: { ctx: AppContext; commands: Accessor<Comman
             activeContent={workspace.activeBuffer()?.content ?? ''}
             initialQuery={overlays.selection()}
             replacing={open().replacing}
+            buffers={open().scope === 'project' ? workspace.replaceOverlay : undefined}
+            suspended={prompts.prompt() !== null}
             onPick={overlays.jumpTo}
             onReplaceOne={
               open().scope === 'file'
@@ -212,7 +230,7 @@ export function OverlayStack(props: { ctx: AppContext; commands: Accessor<Comman
                     if (next === null) return say('That match is gone', 'warn')
                     workspace.applyReplacement(path, next)
                   }
-                : undefined
+                : (match, replacement) => workspace.applyMatchReplace(match, replacement)
             }
             onReplaceAll={
               open().scope === 'file'
@@ -226,7 +244,29 @@ export function OverlayStack(props: { ctx: AppContext; commands: Accessor<Comman
                     workspace.applyReplacement(path, next)
                     say(`Replaced "${query}" in ${basename(path)}`)
                   }
-                : undefined
+                : (query, replacement, options) => {
+                    // The gates get their own messages: an invalid pattern refused as
+                    // "nothing to replace" would read as a project with no matches.
+                    if (!buildQuery(query, options)) return say('Invalid regex', 'warn')
+                    if (query.length < MIN_QUERY) return
+                    const { targets, matches } = planProjectReplace(
+                      app.rootDir,
+                      query,
+                      options,
+                      workspace.replaceOverlay(),
+                    )
+                    if (matches === 0) return say('Nothing to replace')
+                    prompts.setPrompt({
+                      kind: 'replaceProject',
+                      query,
+                      replacement,
+                      options,
+                      paths: targets.map(t => t.path),
+                      matches,
+                      files: targets.length,
+                      flags: searchFlags(options),
+                    })
+                  }
             }
             onClose={() => overlays.setSearch(null)}
           />

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -216,6 +216,7 @@ export function createCommands(ctx: AppContext) {
     findInFile: () => ctx.overlays.setSearch({ scope: 'file' }),
     findInProject: () => ctx.overlays.setSearch({ scope: 'project' }),
     replaceInFile: () => ctx.overlays.setSearch({ scope: 'file', replacing: true }),
+    replaceInProject: () => ctx.overlays.setSearch({ scope: 'project', replacing: true }),
     newFile: () => ctx.prompts.setPrompt({ kind: 'newFile', dir: tree.targetDir() }),
     newFolder: () => ctx.prompts.setPrompt({ kind: 'newFolder', dir: tree.targetDir() }),
     rename: withNode(n => ctx.prompts.setPrompt({ kind: 'rename', target: n.path })),

--- a/src/app/commands.ts
+++ b/src/app/commands.ts
@@ -40,6 +40,7 @@ export interface CommandActions {
   findInFile: () => void
   findInProject: () => void
   replaceInFile: () => void
+  replaceInProject: () => void
   newFile: () => void
   newFolder: () => void
   rename: () => void
@@ -135,6 +136,11 @@ export function buildCommands(actions: CommandActions, ctx: CommandContext): Com
           label: 'Replace in current file',
           hint: 'Ctrl+F then Tab',
           run: actions.replaceInFile,
+        },
+        {
+          id: 'find.replaceProject',
+          label: 'Replace in project',
+          run: actions.replaceInProject,
         },
       ],
     },

--- a/src/app/keyboard.ts
+++ b/src/app/keyboard.ts
@@ -54,6 +54,7 @@ export function installKeyboard(ctx: AppContext, actions: CommandActions) {
     'find.file': () => overlays.setSearch({ scope: 'file' }),
     'find.project': () => overlays.setSearch({ scope: 'project' }),
     'find.replace': actions.replaceInFile,
+    'find.replaceProject': actions.replaceInProject,
     'file.new': () => prompts.setPrompt({ kind: 'newFile', dir: tree.targetDir() }),
     'file.newDir': () => prompts.setPrompt({ kind: 'newFolder', dir: tree.targetDir() }),
     'tabs.close': () => {

--- a/src/app/keymap.ts
+++ b/src/app/keymap.ts
@@ -46,6 +46,7 @@ export const BINDABLE: Bindable[] = [
   { id: 'find.file', label: 'Find in current file', defaults: ['Ctrl+F'] },
   { id: 'find.project', label: 'Find in project', defaults: ['Ctrl+R'], also: [`Ctrl+${ALT}+F`] },
   { id: 'find.replace', label: 'Replace in current file', defaults: [] },
+  { id: 'find.replaceProject', label: 'Replace in project', defaults: [] },
   { id: 'file.new', label: 'New file', defaults: ['Ctrl+N'] },
   { id: 'file.newDir', label: 'New folder', defaults: [`Ctrl+${ALT}+N`] },
   { id: 'tabs.close', label: 'Close tab', defaults: ['Ctrl+W'] },

--- a/src/app/prompts.ts
+++ b/src/app/prompts.ts
@@ -143,6 +143,8 @@ export function createPromptHandlers(deps: {
           touchesTree: true,
           done: () => `Pulled and pushed ${p.branch}`,
         })
+      case 'replaceProject':
+        return workspace.applyProjectReplace(p.paths, p.query, p.replacement, p.options)
       case 'installServer':
         return void lsp.install(p.id, p.name, p.install)
       case 'uninstallServer':
@@ -227,6 +229,13 @@ export function createPromptHandlers(deps: {
           verb: 'quit without saving',
           danger: true,
           message: `Unsaved edits in ${p.names.join(', ')} will be lost. Quit anyway?`,
+        }
+      case 'replaceProject':
+        return {
+          title: 'Replace in project',
+          verb: 'replace',
+          danger: true,
+          message: `Replace ${p.matches} ${p.matches === 1 ? 'match' : 'matches'} in ${p.files} ${p.files === 1 ? 'file' : 'files'}${p.flags}? Closed files are written straight to disk.`,
         }
       case 'undoCommit':
         return {

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -1,4 +1,5 @@
 import type { TextEncoding } from '../core/fs'
+import type { SearchOptions } from '../core/search'
 import type { FetchableInstall } from '../lsp/servers'
 
 /** Which pane owns the keyboard when no overlay is open. */
@@ -47,6 +48,22 @@ export type Prompt =
   | { kind: 'mergeBranch'; name: string }
   /** A push origin refused; `hasUpstream` is what the retry after the pull needs. */
   | { kind: 'pullPush'; branch: string; hasUpstream: boolean }
+  /**
+   * Replace across the project. `paths` is the set the confirm approved —
+   * data only, so the prompt handlers can run the apply without reaching
+   * into the panel that raised it.
+   */
+  | {
+      kind: 'replaceProject'
+      query: string
+      replacement: string
+      options: SearchOptions
+      paths: string[]
+      matches: number
+      files: number
+      /** The active toggles, restated so the user confirms what will run. */
+      flags: string
+    }
   /** A language server is missing and druk can fetch it; `id` is the server id. */
   | { kind: 'installServer'; id: string; name: string; install: FetchableInstall }
   /** Delete druk's own copy of a server. `packages` is what goes with it. */

--- a/src/app/workspace.ts
+++ b/src/app/workspace.ts
@@ -12,10 +12,12 @@ import {
   readTextFile,
   writeFile,
 } from '../core/fs'
-import type { TreeNode } from '../core/fs'
+import type { TextEncoding, TreeNode } from '../core/fs'
 import { isImagePath } from '../core/image'
 import { isMarkdownPath } from '../core/markdown'
 import { isPdfPath } from '../core/pdf'
+import { replaceMatch, replaceProject } from '../core/search'
+import type { Match, SearchOptions } from '../core/search'
 import { loadSession, saveSession } from '../core/session'
 import { trimTrailing } from '../editor/lines'
 import type { DiffFile } from '../ui/DiffView'
@@ -355,6 +357,22 @@ export function createWorkspace(deps: {
   }
 
   /**
+   * The buffers a project search or replace must read instead of the disk:
+   * dirty ones, whose edits the disk does not have, and the active one, whose
+   * undo history is the one place a replace can stay reversible. A clean
+   * non-active buffer is deliberately absent — its disk copy says the same
+   * thing, and the disk route leaves no unsaved tab behind.
+   */
+  const replaceOverlay = (): Map<string, string> => {
+    const overlay = new Map<string, string>()
+    const active = activePath()
+    for (const [path, buffer] of Object.entries(buffers)) {
+      if (buffer && (buffer.dirty || path === active)) overlay.set(path, buffer.content)
+    }
+    return overlay
+  }
+
+  /**
    * Save-then-format: the formatter rewrites the file in place, and the result
    * comes back into the buffer only if nothing typed over it while the tool ran
    * — a keystroke during the run wins, and the next save reformats anyway. The
@@ -551,6 +569,83 @@ export function createWorkspace(deps: {
     return { changed, deleted }
   }
 
+  /**
+   * Replace the one match a panel row points at, wherever its file is: the
+   * overlay's text for buffered paths, a fresh encoding-preserving read for the
+   * rest. The drift guard runs against whichever text the apply would touch.
+   */
+  const applyMatchReplace = (match: Match, replacement: string) => {
+    const open = replaceOverlay().get(match.path)
+    if (open != null) {
+      const next = replaceMatch(open, match, replacement)
+      if (next === null) return say('That match is gone', 'warn')
+      pinTab(match.path)
+      setBuffers(match.path, { content: next, dirty: true })
+      if (match.path === activePath()) editor.pushEdit(next)
+      return
+    }
+    let read: { text: string; encoding: TextEncoding }
+    try {
+      read = readTextFile(match.path)
+    } catch {
+      return say('That match is gone', 'warn')
+    }
+    const next = replaceMatch(read.text, match, replacement)
+    if (next === null) return say('That match is gone', 'warn')
+    const error = writeFile(match.path, next, read.encoding)
+    if (error) return say(`Replace failed: ${error}`, 'error')
+    syncFromDisk()
+    git.bump()
+  }
+
+  /**
+   * Replace across the planned `paths`. Reported counts are what the pass did,
+   * not what the confirm promised — the two drift whenever the tree moves while
+   * the modal is up.
+   */
+  const applyProjectReplace = (
+    paths: readonly string[],
+    query: string,
+    replacement: string,
+    options: SearchOptions,
+  ) => {
+    const overlay = replaceOverlay()
+    const result = replaceProject(paths, query, replacement, options, overlay)
+
+    let pending = 0
+    let wroteDisk = false
+    const active = activePath()
+    for (const file of result.replaced) {
+      if (file.content == null) {
+        wroteDisk = true
+        continue
+      }
+      pinTab(file.path)
+      setBuffers(file.path, { content: file.content, dirty: true })
+      // Any other buffer is updated in the store alone: pushEdit targets the
+      // active editor, and would paint this file's text over the one on screen.
+      if (file.path === active) editor.pushEdit(file.content)
+      pending++
+    }
+    if (wroteDisk) {
+      // The watcher would get there in a debounce anyway; syncing now means the
+      // reloaded clean buffers and the git marks never lag the status message.
+      syncFromDisk()
+      git.bump()
+    }
+
+    const files = result.replaced.length
+    if (result.matches === 0 && result.failed.length === 0) return say('Nothing to replace')
+    const counts = `Replaced ${result.matches} ${result.matches === 1 ? 'match' : 'matches'} in ${files} ${files === 1 ? 'file' : 'files'}`
+    const tail = pending > 0 ? ` — ${pending} in open tabs, unsaved` : ''
+    if (result.failed.length > 0) {
+      const names = result.failed.map(entry => basename(entry.split(' — ')[0]!)).join(', ')
+      say(`${counts}${tail}; failed: ${names}`, 'warn')
+    } else {
+      say(`${counts}${tail}`)
+    }
+  }
+
   /** The watcher's warning for a sync, or null when nothing clashed. */
   const clashWarning = (sync: DiskSync): string | null => {
     const parts: string[] = []
@@ -640,6 +735,9 @@ export function createWorkspace(deps: {
     switchTab,
     onEditorChange,
     applyReplacement,
+    replaceOverlay,
+    applyMatchReplace,
+    applyProjectReplace,
     writeBuffer,
     saveActive,
     saveDirtyOnBlur,

--- a/src/core/search.ts
+++ b/src/core/search.ts
@@ -27,7 +27,10 @@ export function buildQuery(query: string, options: SearchOptions = {}): RegExp |
   const escaped = options.regex ? query : query.replace(/[\\^$.*+?()[\]{}|]/g, '\\$&')
   const wrapped = options.wholeWord ? `\\b(?:${escaped})\\b` : escaped
   try {
-    return new RegExp(wrapped, options.caseSensitive ? 'g' : 'gi')
+    // `m` because searchText counts per line while replaceAll runs over the whole
+    // file: without it `^`/`$` anchor to the string, so an anchored regex is counted
+    // on every line and replaced on one — a confirm promising matches it never makes.
+    return new RegExp(wrapped, options.caseSensitive ? 'gm' : 'gim')
   } catch {
     return null
   }

--- a/src/core/search.ts
+++ b/src/core/search.ts
@@ -1,4 +1,4 @@
-import { listDir, readFile } from './fs'
+import { listDir, readFile, readTextFile, writeFile } from './fs'
 import { ignoredPaths } from './git'
 
 export interface Match {
@@ -119,12 +119,18 @@ function* filesUnder(root: string): Generator<string> {
   }
 }
 
-/** Search every text file under `root`, breadth-first, stopping at the limit. */
+/**
+ * Search every text file under `root`, breadth-first, stopping at the limit.
+ * `buffers` overlays open-buffer text over the disk copy, so what the results
+ * show is what a replace would act on — scanning disk under an edited buffer
+ * lists matches the buffer no longer has, and misses the ones it gained.
+ */
 export function searchProject(
   root: string,
   query: string,
   options: SearchOptions = {},
   limit = DEFAULT_LIMIT,
+  buffers?: ReadonlyMap<string, string>,
 ): Match[] {
   if (!query) return []
   const matches: Match[] = []
@@ -132,14 +138,132 @@ export function searchProject(
   for (const path of filesUnder(root)) {
     if (matches.length >= limit) break
     let content: string
-    try {
-      content = readFile(path)
-    } catch {
-      continue // binary or unreadable
+    const open = buffers?.get(path)
+    if (open != null) {
+      content = open
+    } else {
+      try {
+        content = readFile(path)
+      } catch {
+        continue // binary or unreadable
+      }
     }
     matches.push(...searchText(content, query, path, options, limit - matches.length))
   }
   return matches
+}
+
+/** One file a project replace would touch, counted on the text the apply will see. */
+export interface ReplaceTarget {
+  path: string
+  count: number
+}
+
+/**
+ * Every file a project replace would touch, with true counts — deliberately not
+ * `searchProject`, whose limit exists for a panel that shows 200 rows: a confirm
+ * that says "N matches" must have counted all of them.
+ */
+export function planProjectReplace(
+  root: string,
+  query: string,
+  options: SearchOptions = {},
+  buffers?: ReadonlyMap<string, string>,
+): { targets: ReplaceTarget[]; matches: number } {
+  const targets: ReplaceTarget[] = []
+  let matches = 0
+  if (!query || !buildQuery(query, options)) return { targets, matches }
+
+  for (const path of filesUnder(root)) {
+    let content: string
+    const open = buffers?.get(path)
+    if (open != null) {
+      content = open
+    } else {
+      try {
+        content = readFile(path)
+      } catch {
+        continue
+      }
+    }
+    const count = searchText(content, query, path, options, Infinity).length
+    if (count === 0) continue
+    targets.push({ path, count })
+    matches += count
+  }
+  return { targets, matches }
+}
+
+/** A file transformed by `replaceProject`; `content` means the caller owns applying it. */
+export interface ReplacedFile {
+  path: string
+  /** Occurrences replaced, counted on the text actually transformed. */
+  count: number
+  /**
+   * New text for a path the caller supplied a buffer for. The write is the
+   * caller's: a buffered file's truth is the buffer, and writing its disk copy
+   * here would hand the watcher an edit the buffer does not have.
+   */
+  content?: string
+}
+
+export interface ReplaceProjectResult {
+  replaced: ReplacedFile[]
+  /** Occurrences replaced across every file — apply-time counts, not the plan's. */
+  matches: number
+  /** `path — reason` for every file that could not be read or written. */
+  failed: string[]
+}
+
+/**
+ * Replace across the planned `paths`. Each file is re-read at apply time and
+ * counted on the text actually transformed — the plan's counts age the moment
+ * the confirm goes up, and only what happened here is worth reporting. Files
+ * that appeared after the plan are not touched: the confirm approved a set.
+ * Failures are collected, never thrown — the files before them are already
+ * written, so stopping would neither undo nor finish.
+ */
+export function replaceProject(
+  paths: readonly string[],
+  query: string,
+  replacement: string,
+  options: SearchOptions = {},
+  buffers?: ReadonlyMap<string, string>,
+): ReplaceProjectResult {
+  const replaced: ReplacedFile[] = []
+  const failed: string[] = []
+  let matches = 0
+
+  for (const path of paths) {
+    const open = buffers?.get(path)
+    if (open != null) {
+      const count = searchText(open, query, path, options, Infinity).length
+      if (count === 0) continue
+      replaced.push({ path, count, content: replaceAll(open, query, replacement, options) })
+      matches += count
+      continue
+    }
+    let text: string
+    let encoding
+    try {
+      ;({ text, encoding } = readTextFile(path))
+    } catch (error) {
+      failed.push(`${path} — ${error instanceof Error ? error.message : 'unreadable'}`)
+      continue
+    }
+    const count = searchText(text, query, path, options, Infinity).length
+    if (count === 0) continue
+    // The encoding read is written back: a CRLF or BOM file rewritten with the
+    // default would diff on every line, not just the replaced ones.
+    const error = writeFile(path, replaceAll(text, query, replacement, options), encoding)
+    if (error) {
+      failed.push(`${path} — ${error}`)
+      continue
+    }
+    replaced.push({ path, count })
+    matches += count
+  }
+  return { replaced, matches, failed }
 }
 
 /**

--- a/src/ui/ConfirmModal.tsx
+++ b/src/ui/ConfirmModal.tsx
@@ -37,7 +37,9 @@ export function ConfirmModal(props: ConfirmModalProps) {
   const accent = () => (props.danger ? ui.error : ui.accent)
 
   return (
-    <ModalPanel width={width()} title={` ${props.title} `} accent={accent()}>
+    // Above every panel: a confirm can be raised over the search panel, and a
+    // prompt the thing it suspends can paint over is no prompt at all.
+    <ModalPanel zIndex={200} width={width()} title={` ${props.title} `} accent={accent()}>
       <For each={lines()}>{line => <text fg={ui.text} bg={ui.panelBg} content={line} />}</For>
       <text fg={ui.panelBg} bg={ui.panelBg} content="" />
       <text fg={ui.dim} bg={ui.panelBg} content={`Enter to ${props.verb} · Esc to cancel`} />

--- a/src/ui/SearchPanel.tsx
+++ b/src/ui/SearchPanel.tsx
@@ -390,13 +390,14 @@ export function SearchPanel(props: SearchPanelProps) {
     } else if (k === 'tab' && key.shift && props.scope === 'project') {
       key.preventDefault()
       toggleFoldAll()
+      // In file scope Tab is the replace toggle, as it has always been.
     } else if (k === 'tab' && props.scope === 'file' && props.onReplaceAll) {
       key.preventDefault()
       const next = !replacing()
       setReplacing(next)
       setField(next ? 'replace' : 'query')
-      // Replacing, Tab moves between the two fields — the file-scope muscle
-      // memory, and the only way to edit the query when both fields are up.
+      // Replacing across the project, Tab moves between the two fields — the only
+      // way to edit the query when both are up, so folding gives it up here.
     } else if (k === 'tab' && props.scope === 'project' && replacing()) {
       key.preventDefault()
       setField(f => (f === 'query' ? 'replace' : 'query'))

--- a/src/ui/SearchPanel.tsx
+++ b/src/ui/SearchPanel.tsx
@@ -34,15 +34,27 @@ export interface SearchPanelProps {
   initialQuery?: string
   /** Open with the replacement field already showing. */
   replacing?: boolean
+  /**
+   * Open-buffer text the project scan reads instead of the disk, so the rows
+   * show what a replace would act on. A function: each rescan wants the
+   * buffers as they are now, not as they were when the panel opened.
+   */
+  buffers?: () => ReadonlyMap<string, string>
+  /**
+   * True while a modal owns the keyboard above the panel. Every key handler
+   * in the app hears every key — nothing layers them — so the panel has to
+   * stand down itself or Enter on a confirm would also apply the selected match.
+   */
+  suspended?: boolean
   onPick: (match: Match) => void
-  /** Replace the selected match only. Absent for project-wide search. */
+  /** Replace the selected match only. */
   onReplaceOne?: (match: Match, replacement: string) => void
-  /** Replace every match in the open file. Absent for project-wide search. */
+  /** Replace every match in scope — the whole file, or the whole project. */
   onReplaceAll?: (query: string, replacement: string, options: SearchOptions) => void
   onClose: () => void
 }
 
-const MIN_QUERY = 2
+export const MIN_QUERY = 2
 
 /** Lines either side of the selected match in the preview, at its smallest. */
 const MIN_CONTEXT = 2
@@ -119,6 +131,16 @@ export function SearchPanel(props: SearchPanelProps) {
   const [scanned, setScanned] = createSignal(opened)
   const [replacement, setReplacement] = createSignal('')
   const [replacing, setReplacing] = createSignal(props.replacing ?? false)
+  /**
+   * Which of the two inputs takes typing. In file scope the mount order used to
+   * decide this — the replace field appears on Tab and arrives focused — but a
+   * panel opened with both fields showing has no such order, so it is said
+   * outright. Starts on the replacement only when a selection prefilled the
+   * query — otherwise the query is the thing not yet typed.
+   */
+  const [field, setField] = createSignal<'query' | 'replace'>(
+    props.replacing && props.initialQuery ? 'replace' : 'query',
+  )
   /** Row the selection is nearest to, not the match: rows outnumber matches. */
   const [index, setIndex] = createSignal(0)
   /** Paths whose matches are hidden behind their heading. */
@@ -143,11 +165,16 @@ export function SearchPanel(props: SearchPanelProps) {
 
   const pending = () => props.scope === 'project' && scanned() !== query()
 
+  // Bumped after a project-scope apply: the scan reads disk and buffers, which
+  // no signal covers, so freshness after our own replace is asked for by hand.
+  const [generation, setGeneration] = createSignal(0)
+
   const matches = createMemo(() => {
+    generation()
     const q = scanned()
     if (q.length < MIN_QUERY) return []
     return props.scope === 'project'
-      ? searchProject(props.rootDir, q, options())
+      ? searchProject(props.rootDir, q, options(), undefined, props.buffers?.())
       : searchText(props.activeContent, q, props.activePath ?? '', options())
   })
 
@@ -348,6 +375,7 @@ export function SearchPanel(props: SearchPanelProps) {
   }
 
   useKeys((key: KeyEvent) => {
+    if (props.suspended) return
     const k = key.name
     const option = key.ctrl ? OPTION_KEYS[k] : undefined
     if (option) {
@@ -362,11 +390,17 @@ export function SearchPanel(props: SearchPanelProps) {
     } else if (k === 'tab' && key.shift && props.scope === 'project') {
       key.preventDefault()
       toggleFoldAll()
-    } else if (k === 'tab' && props.onReplaceAll) {
+    } else if (k === 'tab' && props.scope === 'file' && props.onReplaceAll) {
       key.preventDefault()
-      setReplacing(r => !r)
-      // Tab is the replace toggle wherever replacing is offered, so folding only
-      // takes it in project search — which is also the only scope with headings.
+      const next = !replacing()
+      setReplacing(next)
+      setField(next ? 'replace' : 'query')
+      // Replacing, Tab moves between the two fields — the file-scope muscle
+      // memory, and the only way to edit the query when both fields are up.
+    } else if (k === 'tab' && props.scope === 'project' && replacing()) {
+      key.preventDefault()
+      setField(f => (f === 'query' ? 'replace' : 'query'))
+      // Plain project search spends Tab on folding, as it always has.
     } else if (k === 'tab' && props.scope === 'project') {
       key.preventDefault()
       toggleFold()
@@ -381,8 +415,10 @@ export function SearchPanel(props: SearchPanelProps) {
       if (!match) return
       // Replacing one match at a time is the point of the mode; the whole file goes
       // through Ctrl+A, which is the harder move to make by accident.
-      if (replacing() && props.onReplaceOne) props.onReplaceOne(match, replacement())
-      else props.onPick(match)
+      if (replacing() && props.onReplaceOne) {
+        props.onReplaceOne(match, replacement())
+        if (props.scope === 'project') setGeneration(g => g + 1)
+      } else props.onPick(match)
     } else if (k === 'escape') {
       key.preventDefault()
       props.onClose()
@@ -506,9 +542,19 @@ export function SearchPanel(props: SearchPanelProps) {
       width={width()}
       title={props.scope === 'project' ? ' Search in project ' : ' Search in file '}
     >
-      <TextInput value={query()} placeholder="Search…" onInput={type} />
+      <TextInput
+        value={query()}
+        placeholder="Search…"
+        focused={!props.suspended && (!replacing() || field() === 'query')}
+        onInput={type}
+      />
       <Show when={replacing()}>
-        <TextInput value={replacement()} placeholder="Replace with…" onInput={setReplacement} />
+        <TextInput
+          value={replacement()}
+          placeholder="Replace with…"
+          focused={!props.suspended && field() === 'replace'}
+          onInput={setReplacement}
+        />
       </Show>
       <text fg={ui.dim} bg={ui.panelBg} content={summary()} />
       <text fg={ui.panelBg} bg={ui.panelBg} content="" />

--- a/src/ui/TextInput.tsx
+++ b/src/ui/TextInput.tsx
@@ -3,6 +3,8 @@ import { ui } from '../themes'
 export interface TextInputProps {
   value: string
   placeholder?: string
+  /** Default true — two inputs on one panel need exactly one of these. */
+  focused?: boolean
   onInput: (value: string) => void
 }
 
@@ -14,7 +16,7 @@ export interface TextInputProps {
 export function TextInput(props: TextInputProps) {
   return (
     <input
-      focused
+      focused={props.focused ?? true}
       value={props.value}
       placeholder={props.placeholder}
       backgroundColor={ui.solidBg}

--- a/test/replace-project.test.ts
+++ b/test/replace-project.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from 'bun:test'
+import { chmodSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { planProjectReplace, replaceProject } from '../src/core/search'
+import { fixture } from './helpers'
+
+const files = (count: number, perFile: number) =>
+  Object.fromEntries(
+    Array.from({ length: count }, (_, i) => [
+      `f${i}.ts`,
+      Array.from({ length: perFile }, () => 'const value = OLD\n').join(''),
+    ]),
+  )
+
+describe('planProjectReplace', () => {
+  test('counts every match, not the first 200', () => {
+    const dir = fixture(files(30, 10)) // 300 matches
+    const { targets, matches } = planProjectReplace(dir, 'OLD')
+    expect(matches).toBe(300)
+    expect(targets.length).toBe(30)
+  })
+
+  test('an open buffer is counted instead of its disk copy', () => {
+    const dir = fixture({ 'a.ts': 'OLD OLD\n' })
+    const path = join(dir, 'a.ts')
+    const buffers = new Map([[path, 'OLD once, edited away the other\n']])
+    const { matches } = planProjectReplace(dir, 'OLD', {}, buffers)
+    expect(matches).toBe(1)
+  })
+
+  test('an invalid regex plans nothing', () => {
+    const dir = fixture({ 'a.ts': 'OLD\n' })
+    expect(planProjectReplace(dir, '(', { regex: true }).matches).toBe(0)
+  })
+})
+
+describe('replaceProject', () => {
+  test('buffered paths come back as content, disk untouched', () => {
+    const dir = fixture({ 'a.ts': 'disk OLD\n' })
+    const path = join(dir, 'a.ts')
+    const buffers = new Map([[path, 'buffer OLD OLD\n']])
+    const result = replaceProject([path], 'OLD', 'NEW', {}, buffers)
+
+    expect(result.replaced).toEqual([{ path, count: 2, content: 'buffer NEW NEW\n' }])
+    expect(readFileSync(path, 'utf8')).toBe('disk OLD\n')
+  })
+
+  test('a buffer that no longer holds the query is left alone', () => {
+    const dir = fixture({ 'a.ts': 'disk OLD\n' })
+    const path = join(dir, 'a.ts')
+    const buffers = new Map([[path, 'the buffer moved on\n']])
+    const result = replaceProject([path], 'OLD', 'NEW', {}, buffers)
+
+    expect(result.replaced).toEqual([])
+    expect(result.matches).toBe(0)
+    expect(readFileSync(path, 'utf8')).toBe('disk OLD\n')
+  })
+
+  test('CRLF and BOM files keep their spelling', () => {
+    const dir = fixture({})
+    const crlf = join(dir, 'crlf.ts')
+    const bom = join(dir, 'bom.ts')
+    writeFileSync(crlf, 'one OLD\r\ntwo\r\n')
+    writeFileSync(bom, '﻿OLD here\n')
+
+    const result = replaceProject([crlf, bom], 'OLD', 'NEW')
+    expect(result.matches).toBe(2)
+    expect(readFileSync(crlf, 'utf8')).toBe('one NEW\r\ntwo\r\n')
+    expect(readFileSync(bom, 'utf8')).toBe('﻿NEW here\n')
+  })
+
+  test('counts are apply-time, not plan-time', () => {
+    const dir = fixture({ 'a.ts': 'OLD\n' })
+    const path = join(dir, 'a.ts')
+    const plan = planProjectReplace(dir, 'OLD')
+    expect(plan.matches).toBe(1)
+
+    writeFileSync(path, 'OLD OLD OLD\n') // grows between plan and apply
+    const result = replaceProject(
+      plan.targets.map(t => t.path),
+      'OLD',
+      'NEW',
+    )
+    expect(result.matches).toBe(3)
+  })
+
+  test('a vanished file is named, the rest still land', () => {
+    const dir = fixture({ 'gone.ts': 'OLD\n', 'stays.ts': 'OLD\n' })
+    const gone = join(dir, 'gone.ts')
+    const stays = join(dir, 'stays.ts')
+    rmSync(gone)
+
+    const result = replaceProject([gone, stays], 'OLD', 'NEW')
+    expect(result.failed.length).toBe(1)
+    expect(result.failed[0]).toContain('gone.ts')
+    expect(readFileSync(stays, 'utf8')).toBe('NEW\n')
+  })
+
+  test('an unwritable file is named, the ones after it still land', () => {
+    const dir = fixture({ 'locked.ts': 'OLD\n', 'open.ts': 'OLD\n' })
+    const locked = join(dir, 'locked.ts')
+    const open = join(dir, 'open.ts')
+    chmodSync(locked, 0o444)
+
+    const result = replaceProject([locked, open], 'OLD', 'NEW')
+    chmodSync(locked, 0o644)
+    // Root ignores file modes; the write "succeeds" there and the test has nothing to see.
+    if (process.getuid?.() !== 0) {
+      expect(result.failed.length).toBe(1)
+      expect(result.failed[0]).toContain('locked.ts')
+      expect(readFileSync(locked, 'utf8')).toBe('OLD\n')
+    }
+    expect(readFileSync(open, 'utf8')).toBe('NEW\n')
+  })
+
+  test('$& and $1 land literally, as in-file replace pins', () => {
+    const dir = fixture({ 'a.ts': 'OLD\n' })
+    const path = join(dir, 'a.ts')
+    replaceProject([path], 'OLD', '$&$1')
+    expect(readFileSync(path, 'utf8')).toBe('$&$1\n')
+  })
+
+  test('a zero-width regex replaces matches, not every column', () => {
+    const dir = fixture({ 'a.ts': 'baa b\n' })
+    const path = join(dir, 'a.ts')
+    replaceProject([path], 'a*', 'X', { regex: true })
+    expect(readFileSync(path, 'utf8')).toBe('bX b\n')
+  })
+})

--- a/test/replace-project.test.ts
+++ b/test/replace-project.test.ts
@@ -127,4 +127,24 @@ describe('replaceProject', () => {
     replaceProject([path], 'a*', 'X', { regex: true })
     expect(readFileSync(path, 'utf8')).toBe('bX b\n')
   })
+
+  // The confirm states a count before anything is written, so a pattern counted per
+  // line and replaced per file would promise matches the pass never makes.
+  test('an anchored regex replaces every line it was counted on', () => {
+    const dir = fixture({ 'a.ts': 'const a = 1\nconst b = 2\nconst c = 3\n' })
+    const path = join(dir, 'a.ts')
+    expect(planProjectReplace(dir, '^const', { regex: true }).matches).toBe(3)
+
+    const result = replaceProject([path], '^const', 'let', { regex: true })
+    expect(result.matches).toBe(3)
+    expect(readFileSync(path, 'utf8')).toBe('let a = 1\nlet b = 2\nlet c = 3\n')
+  })
+
+  test('a trailing anchor counts and replaces alike', () => {
+    const dir = fixture({ 'a.ts': 'const a = 1\nconst b = 2\n' })
+    const path = join(dir, 'a.ts')
+    const result = replaceProject([path], String.raw`\d$`, 'N', { regex: true })
+    expect(result.matches).toBe(2)
+    expect(readFileSync(path, 'utf8')).toBe('const a = N\nconst b = N\n')
+  })
 })

--- a/test/replace-project.test.tsx
+++ b/test/replace-project.test.tsx
@@ -1,0 +1,150 @@
+import { expect, test } from 'bun:test'
+import { readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import {
+  fixture,
+  launch,
+  openFile,
+  press,
+  pressEscape,
+  runCommand,
+  settle,
+  untilFrame,
+} from './helpers'
+import type { Harness } from './helpers'
+
+const PROJECT = {
+  'a.ts': 'const OLD = 1\n',
+  'b.ts': 'let OLD = 2\n',
+  'c.ts': 'var OLD = 3\n',
+}
+
+const SIZE = { width: 100, height: 30 }
+
+/** Open project replace from the palette and type both fields. */
+async function openReplace(t: Harness, query: string, replacement: string) {
+  await runCommand(t, 'Replace in project')
+  await press(t, i => void i.typeText(query)) // nothing selected: the query field starts focused
+  await press(t, i => i.pressTab())
+  await press(t, i => void i.typeText(replacement))
+  await settle(t, 300) // past the scan debounce
+}
+
+test('the palette opens project search with the replace field showing', async () => {
+  const t = await launch(fixture(PROJECT), {}, SIZE)
+  await runCommand(t, 'Replace in project')
+  const frame = t.captureCharFrame()
+  expect(frame).toContain('Search in project')
+  expect(frame).toContain('Replace with…')
+})
+
+test('rows preview the hit beside its replacement', async () => {
+  const t = await launch(fixture(PROJECT), {}, SIZE)
+  await openReplace(t, 'OLD', 'NEW')
+  expect(t.captureCharFrame()).toContain('const OLDNEW = 1')
+})
+
+test('replace-all routes buffers and disk, and says which was which', async () => {
+  const dir = fixture(PROJECT)
+  // Autosave off: switching tabs would otherwise save b.ts and unmake the dirty case.
+  const t = await launch(dir, { autoSaveOnBlur: false }, SIZE)
+  // b.ts: open and made dirty. a.ts: open, clean, and active. c.ts: closed.
+  await openFile(t, 'b.ts')
+  await press(t, i => void i.typeText('x'))
+  await openFile(t, 'a.ts')
+
+  await openReplace(t, 'OLD', 'NEW')
+  await press(t, i => i.pressKey('a', { ctrl: true }))
+  await untilFrame(t, 'Replace 3 matches in 3 files')
+  await press(t, i => i.pressEnter())
+  await untilFrame(t, 'Replaced 3 matches in 3 files')
+
+  const frame = t.captureCharFrame()
+  expect(frame).toContain('2 in open tabs, unsaved')
+  // The two buffer-routed files kept their disks; the closed one was written.
+  expect(readFileSync(join(dir, 'a.ts'), 'utf8')).toBe('const OLD = 1\n')
+  expect(readFileSync(join(dir, 'b.ts'), 'utf8')).toBe('let OLD = 2\n')
+  expect(readFileSync(join(dir, 'c.ts'), 'utf8')).toBe('var NEW = 3\n')
+  // The active buffer took the edit — and can give it back as one undo step.
+  expect(frame).toContain('const NEW = 1')
+  await press(t, i => i.pressKey('z', { ctrl: true }))
+  expect(t.captureCharFrame()).toContain('const OLD = 1')
+})
+
+test('the confirm suspends the panel: one Enter, no stray apply', async () => {
+  const dir = fixture(PROJECT)
+  const t = await launch(dir, {}, SIZE)
+  await openReplace(t, 'OLD', 'NEW')
+  await press(t, i => i.pressKey('a', { ctrl: true }))
+  await untilFrame(t, 'Replace 3 matches')
+
+  // Escape cancels the modal and only the modal — the panel keeps its state.
+  await pressEscape(t)
+  await settle(t)
+  const frame = t.captureCharFrame()
+  expect(frame).not.toContain('Replace 3 matches')
+  expect(frame).toContain('Search in project')
+  expect(frame).toContain('const OLDNEW = 1')
+  expect(readFileSync(join(dir, 'a.ts'), 'utf8')).toBe('const OLD = 1\n')
+
+  // Confirming closes the panel and applies everywhere — exactly once.
+  await press(t, i => i.pressKey('a', { ctrl: true }))
+  await untilFrame(t, 'Replace 3 matches')
+  await press(t, i => i.pressEnter())
+  await untilFrame(t, 'Replaced 3 matches in 3 files')
+  expect(t.captureCharFrame()).not.toContain('Search in project')
+  expect(readFileSync(join(dir, 'c.ts'), 'utf8')).toBe('var NEW = 3\n')
+})
+
+test('Enter applies one match and the row leaves the list', async () => {
+  const dir = fixture({ 'a.ts': 'OLD\n', 'b.ts': 'OLD\n' })
+  const t = await launch(dir, {}, SIZE)
+  await openReplace(t, 'OLD', 'NEW')
+  await untilFrame(t, '1 of 2 in 2 files')
+
+  await press(t, i => i.pressEnter())
+  await settle(t, 300)
+  await untilFrame(t, '1 of 1 in 1 file')
+  // One file changed on disk, the other is still listed for its turn.
+  const disks = [
+    readFileSync(join(dir, 'a.ts'), 'utf8'),
+    readFileSync(join(dir, 'b.ts'), 'utf8'),
+  ].toSorted()
+  expect(disks).toEqual(['NEW\n', 'OLD\n'])
+})
+
+test('a match drifted on disk is refused, not applied askew', async () => {
+  const dir = fixture({ 'a.ts': 'keep OLD here\n' })
+  const t = await launch(dir, {}, SIZE)
+  await openReplace(t, 'OLD', 'NEW')
+  await untilFrame(t, '1 of 1')
+
+  writeFileSync(join(dir, 'a.ts'), 'the line moved\nkeep OLD here\n')
+  await press(t, i => i.pressEnter())
+  await untilFrame(t, 'That match is gone')
+  expect(readFileSync(join(dir, 'a.ts'), 'utf8')).toBe('the line moved\nkeep OLD here\n')
+})
+
+test('an invalid regex refuses with its own message', async () => {
+  const t = await launch(fixture(PROJECT), {}, SIZE)
+  await runCommand(t, 'Replace in project')
+  await press(t, i => void i.typeText('(('))
+  await press(t, i => i.pressKey('r', { ctrl: true })) // regex mode
+  await press(t, i => i.pressKey('a', { ctrl: true }))
+  await untilFrame(t, 'Invalid regex')
+})
+
+test('the confirm counts past the panel display cap', async () => {
+  const many = Object.fromEntries(
+    Array.from({ length: 30 }, (_, i) => [
+      `f${i}.ts`,
+      Array.from({ length: 10 }, () => 'OLD\n').join(''),
+    ]),
+  )
+  const t = await launch(fixture(many), {}, SIZE)
+  await openReplace(t, 'OLD', 'NEW')
+  await untilFrame(t, '200+')
+  await press(t, i => i.pressKey('a', { ctrl: true }))
+  await untilFrame(t, 'Replace 300 matches in 30 files')
+})


### PR DESCRIPTION
Project-wide replace — IMPROVEMENTS.md calls it "still the big daily-driver hole" (P0.5), and the competitive gap map lists it as the one place Micro, Helix and Neovim all lead. This adds it to the project-search panel, the way the roadmap sketches: preview + confirm.

*Find → Replace in project* opens Ctrl+R's panel with the replace field showing. Every row previews the hit beside its replacement (the strikethrough rendering the panel already had for file scope). `Enter` applies the selected match and the list refreshes; `Ctrl+A` raises a confirm first, then applies everywhere.

Decisions worth a reviewer's attention:

- **The confirm counts for real.** The panel caps at 200 rows; the confirm's numbers come from an uncapped scan at confirm time, and the completion message reports what the apply pass actually did — the two can differ when the tree moves while the modal is up, and only the second is worth reporting.
- **The scan reads open buffers.** Project search scanned disk only, which was fine until replace: acting on buffers while listing disk would show matches the buffer no longer has and miss ones it gained. In replace mode the scan overlays dirty and active buffers over their disk copies, so what is listed is what is replaced. (Plain search is unchanged.)
- **Routing.** Dirty buffers and the active file take the edit in their buffer — the tab goes unsaved, the active file keeps one-step undo, and no disk write can land under unsaved edits (which is what raises the clash warning). Everything else is written to disk with `readTextFile`'s encoding passed back, so CRLF/BOM files change only on the replaced lines. The completion message says how many landed on disk and how many sit unsaved in tabs.
- **Failures are named, never thrown.** A file deleted, binary, or unwritable mid-pass is reported by name and the pass continues — earlier writes are already on disk, so stopping would neither undo nor finish.
- **Tab.** Plain project search keeps Tab for folding. With the replace field up, Tab moves between the two input boxes — the panel opens with both showing, so mount order can no longer decide focus (that also meant giving `TextInput` a `focused` prop and `ConfirmModal` a zIndex above the search panel, which had never needed to coexist before).
- Replacement text stays literal (`$1` inserted verbatim), matching what `test/replace.test.tsx` pins for file scope.

Tests: 11 unit cases for the plan/apply passes (true counts past the cap, encoding round-trip, buffer-vs-disk divergence both directions, vanished and unwritable files mid-pass, apply-time counts) and 8 UI cases (routing across dirty/clean/closed with the two-part message, confirm suspension — one Enter, no stray apply — cancel returning to the live panel, per-match refresh, drift refusal, invalid-regex gate, true counts past the cap). `bun run check` is green.
