### PR TITLE
feat(files): save every unsaved tab from the palette

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,7 +201,8 @@ catalog is reported in the status bar at startup, a file whose language no
 installed extension serves offers the extension that does, and a config naming a theme
 nothing registers is offered its extension back (`extensionUpdates` turns the whole of
 that off, `extensionRegistry` points it at a fork),
-file watching with conflict prompts,
+file watching with conflict prompts, a save-all palette command (every unsaved tab
+through the same clash-safe path the blur autosave uses, skips and failures named),
 per-project session restore, and a startup update check.
 
 **Everything extensible is an extension now, and most of them live in `extensions/`.**

--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ status bar with the branch, unsaved state and cursor position.
   the palette has it as *View → Collapse folders in sidebar*.
 - Opening a file from the tree previews it: the tab is *italic* and the next file you
   open takes its place. Double-click it, or start editing, and the tab stays for good.
-- `Ctrl+S` saves. Closing a tab with unsaved edits asks first.
+- `Ctrl+S` saves; *File → Save all* in the palette writes every unsaved tab at once.
+  Closing a tab with unsaved edits asks first.
 - `F1` (or `Ctrl+Shift+P` where the terminal can send it) opens the command palette —
   every feature is in there, and typing filters it, so you never have to remember a
   shortcut. `F1` → `Keyboard shortcuts` shows them all.

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -191,6 +191,7 @@ export function createCommands(ctx: AppContext) {
 
   const actions = {
     save: workspace.saveActive,
+    saveAll: workspace.saveAll,
     openFile: () => ctx.overlays.setPicker('files'),
     switchTab: () => ctx.overlays.setPicker('tabs'),
     closeOthers: () => {

--- a/src/app/commands.ts
+++ b/src/app/commands.ts
@@ -125,7 +125,6 @@ export function buildCommands(actions: CommandActions, ctx: CommandContext): Com
   return [
     { id: 'open', label: 'Open file…', hint: 'Ctrl+P', run: actions.openFile },
     { id: 'save', label: 'Save file', hint: 'Ctrl+S', run: actions.save },
-    { id: 'saveAll', label: 'Save all', run: actions.saveAll },
     { id: 'goto', label: 'Go to line…', hint: 'Ctrl+G', run: actions.gotoLine },
     { id: 'undo', label: 'Undo', hint: 'Ctrl+Z', run: actions.undo },
     { id: 'redo', label: 'Redo', hint: 'Ctrl+Y', run: actions.redo },
@@ -157,6 +156,7 @@ export function buildCommands(actions: CommandActions, ctx: CommandContext): Com
       id: 'file',
       label: 'File',
       children: [
+        { id: 'file.saveAll', label: 'Save all', run: actions.saveAll },
         { id: 'file.new', label: 'New file', hint: 'Ctrl+N', run: actions.newFile },
         { id: 'file.newDir', label: 'New folder', hint: `Ctrl+${ALT}+N`, run: actions.newFolder },
         { id: 'file.rename', label: 'Rename…', hint: 'r', run: actions.rename },

--- a/src/app/commands.ts
+++ b/src/app/commands.ts
@@ -29,6 +29,7 @@ export interface Command {
 
 export interface CommandActions {
   save: () => void
+  saveAll: () => void
   openFile: () => void
   switchTab: () => void
   closeOthers: () => void
@@ -124,6 +125,7 @@ export function buildCommands(actions: CommandActions, ctx: CommandContext): Com
   return [
     { id: 'open', label: 'Open file…', hint: 'Ctrl+P', run: actions.openFile },
     { id: 'save', label: 'Save file', hint: 'Ctrl+S', run: actions.save },
+    { id: 'saveAll', label: 'Save all', run: actions.saveAll },
     { id: 'goto', label: 'Go to line…', hint: 'Ctrl+G', run: actions.gotoLine },
     { id: 'undo', label: 'Undo', hint: 'Ctrl+Z', run: actions.undo },
     { id: 'redo', label: 'Redo', hint: 'Ctrl+Y', run: actions.redo },

--- a/src/app/keyboard.ts
+++ b/src/app/keyboard.ts
@@ -49,6 +49,7 @@ export function installKeyboard(ctx: AppContext, actions: CommandActions) {
     'peek': togglePeek,
     'open': () => overlays.setPicker('files'),
     'save': workspace.saveActive,
+    'saveAll': workspace.saveAll,
     'goto': () => prompts.setPrompt({ kind: 'gotoLine' }),
     'goto.definition': actions.gotoDefinition,
     'goto.file': actions.openFileUnderCursor,

--- a/src/app/keyboard.ts
+++ b/src/app/keyboard.ts
@@ -49,7 +49,7 @@ export function installKeyboard(ctx: AppContext, actions: CommandActions) {
     'peek': togglePeek,
     'open': () => overlays.setPicker('files'),
     'save': workspace.saveActive,
-    'saveAll': workspace.saveAll,
+    'file.saveAll': workspace.saveAll,
     'goto': () => prompts.setPrompt({ kind: 'gotoLine' }),
     'goto.definition': actions.gotoDefinition,
     'goto.file': actions.openFileUnderCursor,

--- a/src/app/keymap.ts
+++ b/src/app/keymap.ts
@@ -40,6 +40,7 @@ export const BINDABLE: Bindable[] = [
   { id: 'peek', label: 'Peek at every key', defaults: ['Ctrl+K'] },
   { id: 'open', label: 'Open file…', defaults: ['Ctrl+P', 'Ctrl+O'] },
   { id: 'save', label: 'Save file', defaults: ['Ctrl+S'] },
+  { id: 'saveAll', label: 'Save all', defaults: [] },
   { id: 'goto', label: 'Go to line…', defaults: ['Ctrl+G'] },
   { id: 'goto.definition', label: 'Go to definition', defaults: ['F12'] },
   { id: 'goto.file', label: 'Open file under cursor', defaults: [`Ctrl+${ALT}+O`] },

--- a/src/app/keymap.ts
+++ b/src/app/keymap.ts
@@ -40,7 +40,7 @@ export const BINDABLE: Bindable[] = [
   { id: 'peek', label: 'Peek at every key', defaults: ['Ctrl+K'] },
   { id: 'open', label: 'Open file…', defaults: ['Ctrl+P', 'Ctrl+O'] },
   { id: 'save', label: 'Save file', defaults: ['Ctrl+S'] },
-  { id: 'saveAll', label: 'Save all', defaults: [] },
+  { id: 'file.saveAll', label: 'Save all', defaults: [] },
   { id: 'goto', label: 'Go to line…', defaults: ['Ctrl+G'] },
   { id: 'goto.definition', label: 'Go to definition', defaults: ['F12'] },
   { id: 'goto.file', label: 'Open file under cursor', defaults: [`Ctrl+${ALT}+O`] },

--- a/src/app/workspace.ts
+++ b/src/app/workspace.ts
@@ -473,7 +473,8 @@ export function createWorkspace(deps: {
     return writeBuffer(path, buffer.content) ? 'saved' : 'failed'
   }
 
-  const saveDirtyOnBlur = () => {
+  /** Every dirty buffer through the clash-safe autoSave; the callers pick the voice. */
+  const saveDirty = () => {
     const skipped: string[] = []
     const failed: string[] = []
     let saved = 0
@@ -484,7 +485,21 @@ export function createWorkspace(deps: {
       else if (result === 'skipped') skipped.push(basename(path))
       else failed.push(basename(path))
     }
+    return { saved, skipped, failed }
+  }
+
+  const saveDirtyOnBlur = () => {
+    const { saved, skipped, failed } = saveDirty()
     // One file keeps writeBuffer's own message; several get a count instead.
+    if (saved > 1) say(`Saved ${saved} files`)
+    if (skipped.length > 0) say(`${CLASH_CHANGED}${skipped.join(', ')}`, 'warn')
+    if (failed.length > 0) say(`Save failed: ${failed.join(', ')}`, 'error')
+  }
+
+  const saveAll = () => {
+    const { saved, skipped, failed } = saveDirty()
+    if (saved === 0 && skipped.length === 0 && failed.length === 0) return say('Nothing to save')
+    // As on blur: one file keeps writeBuffer's own named message.
     if (saved > 1) say(`Saved ${saved} files`)
     if (skipped.length > 0) say(`${CLASH_CHANGED}${skipped.join(', ')}`, 'warn')
     if (failed.length > 0) say(`Save failed: ${failed.join(', ')}`, 'error')
@@ -740,6 +755,7 @@ export function createWorkspace(deps: {
     applyProjectReplace,
     writeBuffer,
     saveActive,
+    saveAll,
     saveDirtyOnBlur,
     resolveConflict,
     syncFromDisk,

--- a/test/save-all.test.tsx
+++ b/test/save-all.test.tsx
@@ -1,0 +1,72 @@
+import { expect, test } from 'bun:test'
+import { chmodSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { fixture, launch, openFile, press, runCommand, untilFrame } from './helpers'
+import type { Harness } from './helpers'
+
+const PROJECT = {
+  'a.ts': 'const a = 1\n',
+  'b.ts': 'const b = 2\n',
+  'c.ts': 'const c = 3\n',
+}
+
+const SIZE = { width: 100, height: 30 }
+
+/** Open `name` and type at its start, leaving the tab dirty. */
+async function dirty(t: Harness, name: string) {
+  await openFile(t, name)
+  await press(t, i => void i.typeText('x'))
+}
+
+test('saves every dirty tab and counts them', async () => {
+  const dir = fixture(PROJECT)
+  const t = await launch(dir, { autoSaveOnBlur: false }, SIZE)
+  await dirty(t, 'a.ts')
+  await dirty(t, 'b.ts')
+  await openFile(t, 'c.ts') // open and clean
+
+  await runCommand(t, 'Save all')
+  await untilFrame(t, 'Saved 2 files')
+  expect(readFileSync(join(dir, 'a.ts'), 'utf8')).toBe('xconst a = 1\n')
+  expect(readFileSync(join(dir, 'b.ts'), 'utf8')).toBe('xconst b = 2\n')
+  expect(readFileSync(join(dir, 'c.ts'), 'utf8')).toBe('const c = 3\n')
+})
+
+test('with nothing unsaved it says so and writes nothing', async () => {
+  const dir = fixture(PROJECT)
+  const t = await launch(dir, { autoSaveOnBlur: false }, SIZE)
+  await openFile(t, 'a.ts')
+
+  await runCommand(t, 'Save all')
+  await untilFrame(t, 'Nothing to save')
+  expect(readFileSync(join(dir, 'a.ts'), 'utf8')).toBe('const a = 1\n')
+})
+
+test('a file changed on disk underneath is skipped with the warning', async () => {
+  const dir = fixture(PROJECT)
+  const t = await launch(dir, { autoSaveOnBlur: false }, SIZE)
+  await dirty(t, 'a.ts')
+
+  writeFileSync(join(dir, 'a.ts'), 'someone else wrote this\n')
+  await runCommand(t, 'Save all')
+  await untilFrame(t, 'Changed on disk with unsaved edits: a.ts')
+  expect(readFileSync(join(dir, 'a.ts'), 'utf8')).toBe('someone else wrote this\n')
+})
+
+test('a write failure is named, the other files still land', async () => {
+  const dir = fixture(PROJECT)
+  const t = await launch(dir, { autoSaveOnBlur: false }, SIZE)
+  await dirty(t, 'a.ts')
+  await dirty(t, 'b.ts')
+
+  chmodSync(join(dir, 'a.ts'), 0o444)
+  await runCommand(t, 'Save all')
+  // Root ignores file modes, so the failure branch is unobservable there.
+  if (process.getuid?.() !== 0) {
+    await untilFrame(t, 'Save failed: a.ts')
+    expect(readFileSync(join(dir, 'a.ts'), 'utf8')).toBe('const a = 1\n')
+  }
+  chmodSync(join(dir, 'a.ts'), 0o644)
+  expect(readFileSync(join(dir, 'b.ts'), 'utf8')).toBe('xconst b = 2\n')
+})


### PR DESCRIPTION
Save all — IMPROVEMENTS.md P0.7, and with it the P0 section's last-but-one open item.

*File → Save all* in the palette writes every unsaved tab. The loop is the blur autosave's, extracted and shared rather than duplicated: each file goes through the same clash-safe path, so a file whose disk copy moved underneath is skipped with the existing warning instead of overwritten, and write failures are named. The only new voice is the empty case — "Nothing to save" — and a single file keeps `writeBuffer`'s own named message, as on blur. Bindable with no default chord, following the `view.wrap` arrangement.

Tests: two dirty tabs plus a clean one saved and counted, the empty case, a disk-changed file skipped with the clash warning and its disk left alone, and a write failure named while the other files still land. The existing blur autosave tests are untouched. `bun run check` is green.
