### PR TITLE
docs: tighten three one-line comments

### DIFF
--- a/src/core/process.ts
+++ b/src/core/process.ts
@@ -91,7 +91,7 @@ export function run(bin: string, args: string[], options: RunOptions): Promise<P
   })
 }
 
-/** Whether `result` failed because the program is not there at all. */
+/** The program is not on PATH at all, as against having run and failed. */
 export const notInstalled = (result: ProcessResult): boolean => result.error?.code === 'ENOENT'
 
 /** The first non-empty line of `text`, which is the useful half of most tool output. */

--- a/src/editor/columns.ts
+++ b/src/editor/columns.ts
@@ -18,7 +18,7 @@
 /** OpenTUI draws a tab as the indicator glyph plus one blank, with no setting for it. */
 const TAB_CELLS = 2
 
-/** The cell character column `col` of `line` is drawn at. */
+/** Character column `col` in cell space — the two differ wherever a tab sits. */
 export function cellColumn(line: string, col: number): number {
   const stop = Math.min(col, line.length)
   let cells = col - stop // a column past the end of the line counts as itself

--- a/src/ui/text.ts
+++ b/src/ui/text.ts
@@ -7,7 +7,7 @@
  * grows to two, five, ninety lines and takes the panel's layout with it.
  */
 
-/** `text` in at most `room` columns, ending in an ellipsis where it was cut. */
+/** At most `room` columns, the ellipsis counted inside the budget. */
 export function cut(text: string, room: number): string {
   if (room <= 0) return ''
   return text.length > room ? `${text.slice(0, room - 1)}…` : text


### PR DESCRIPTION
Test PR for exercising the review panel's forge fetch. Three one-line comments that restated their function's name and signature now say the non-obvious part instead:

- `notInstalled` — distinguishes a missing program from a program that ran and failed
- `cut` — the ellipsis is counted inside the column budget
- `cellColumn` — maps between character and cell column space, which only diverge at a tab

Comment-only; no behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)