### PR TITLE
feat(editor): support double-click and triple-click selection behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,11 @@ overrides while it is on, since there the shape is what tells normal from insert
 word wrap on by default with a toggle (`wrap`, palette → View → Toggle word wrap —
 off, a long line's tail is reached by moving the cursor into it, since OpenTUI
 scrolls sideways only with the caret),
+selecting a word by double-click and a line by triple-click (OpenTUI has no such
+event, so both are counted from consecutive mouse-downs at one cell, the way the
+file tree already counts its own; a line terminator is not a token, so a click
+past the end of a line or on a blank line selects nothing rather than the `\n` —
+which the next keystroke would otherwise pull the following line up over),
 code folding (`Ctrl+Opt+S` / `Ctrl+Opt+E`, palette → Editor → Fold / Unfold block at
 cursor, and fold/unfold everything: blocks come from indentation rather than from the
 grammar, so they work for the languages druk paints with `patterns` and no tree at

--- a/src/editor/words.ts
+++ b/src/editor/words.ts
@@ -1,12 +1,18 @@
 /** Identifier characters — same set the completion prefix uses. */
 const WORD_CHAR = /[A-Za-z0-9_$]/
 
-type CharClass = 'word' | 'space' | 'other'
+type CharClass = 'word' | 'space' | 'newline' | 'other'
 
 function classOf(ch: string): CharClass {
   if (WORD_CHAR.test(ch)) return 'word'
-  // Newlines are not part of a space run: a double-click on indent must not
-  // swallow the previous line's trailing spaces.
+  // A line terminator is its own class, and never selectable as a token. Left in
+  // `other` it joins the punctuation run at the end of a line, so a double-click
+  // on `(` in `foo();` selects `();\n` and the next keystroke eats the line
+  // break; and a click past a line's last character — where the caret clamps to
+  // the `\n` — selects a run of blank lines.
+  if (ch === '\n' || ch === '\r') return 'newline'
+  // Newlines are not part of a space run either: a double-click on indent must
+  // not swallow the previous line's trailing spaces.
   if (ch === ' ' || ch === '\t') return 'space'
   return 'other'
 }
@@ -15,13 +21,16 @@ function classOf(ch: string): CharClass {
  * Exclusive `[start, end)` of the token under `offset` — an identifier, a run of
  * spaces/tabs, or a run of the same other character class (punctuation). The
  * same rule applies inside quoted strings: a double-click on `hello` in
- * `"hello world"` selects `hello`, not the whole literal.
+ * `"hello world"` selects `hello`, not the whole literal. A caret on a line
+ * terminator selects nothing, which is what a click past the end of a line and a
+ * click on a blank line both land on.
  */
 export function wordRangeAt(text: string, offset: number): { start: number; end: number } {
   if (text.length === 0) return { start: 0, end: 0 }
   const at = Math.min(Math.max(0, offset), text.length)
   const ch = at < text.length ? text[at]! : text[at - 1]!
   const kind = classOf(ch)
+  if (kind === 'newline') return { start: at, end: at }
   // When the caret sits past the last character, grow from that character.
   let start = at < text.length ? at : at - 1
   let end = start + 1

--- a/src/editor/words.ts
+++ b/src/editor/words.ts
@@ -1,0 +1,41 @@
+/** Identifier characters — same set the completion prefix uses. */
+const WORD_CHAR = /[A-Za-z0-9_$]/
+
+type CharClass = 'word' | 'space' | 'other'
+
+function classOf(ch: string): CharClass {
+  if (WORD_CHAR.test(ch)) return 'word'
+  // Newlines are not part of a space run: a double-click on indent must not
+  // swallow the previous line's trailing spaces.
+  if (ch === ' ' || ch === '\t') return 'space'
+  return 'other'
+}
+
+/**
+ * Exclusive `[start, end)` of the token under `offset` — an identifier, a run of
+ * spaces/tabs, or a run of the same other character class (punctuation). The
+ * same rule applies inside quoted strings: a double-click on `hello` in
+ * `"hello world"` selects `hello`, not the whole literal.
+ */
+export function wordRangeAt(text: string, offset: number): { start: number; end: number } {
+  if (text.length === 0) return { start: 0, end: 0 }
+  const at = Math.min(Math.max(0, offset), text.length)
+  const ch = at < text.length ? text[at]! : text[at - 1]!
+  const kind = classOf(ch)
+  // When the caret sits past the last character, grow from that character.
+  let start = at < text.length ? at : at - 1
+  let end = start + 1
+  while (start > 0 && classOf(text[start - 1]!) === kind) start--
+  while (end < text.length && classOf(text[end]!) === kind) end++
+  return { start, end }
+}
+
+/** Exclusive `[start, end)` of the line containing `offset`, including its `\n`. */
+export function lineRangeAt(text: string, offset: number): { start: number; end: number } {
+  if (text.length === 0) return { start: 0, end: 0 }
+  const at = Math.min(Math.max(0, offset), text.length)
+  const start = text.lastIndexOf('\n', at - 1) + 1
+  const nl = text.indexOf('\n', at)
+  const end = nl >= 0 ? nl + 1 : text.length
+  return { start, end }
+}

--- a/src/ui/EditorPane.tsx
+++ b/src/ui/EditorPane.tsx
@@ -24,6 +24,7 @@ import { handleTyping } from '../editor/typing'
 import { handleVimKey, initialVimState } from '../editor/vim'
 import type { VimMode } from '../editor/vim'
 import { lineAt, logicalWindow } from '../editor/window'
+import { lineRangeAt, wordRangeAt } from '../editor/words'
 import { commentPrefix } from '../languages'
 import {
   computeHighlights,
@@ -270,6 +271,37 @@ export function ignoreScrollOutsideBounds(el: TextareaRenderable) {
       if (!inside) return
     }
     handle(event)
+  }
+}
+
+/** OpenTUI has no double-click event, so detect it from consecutive downs — same as FileTree. */
+const DOUBLE_CLICK_MS = 400
+
+/**
+ * Expand the selection on a double-click (word) or triple-click (line). Runs after
+ * the buffer has taken the click: the renderer places the caret in `startSelection`
+ * before this hook sees the down, and `setSelection` clears that zero-width mouse
+ * selection so the word/line range is what survives the mouse-up.
+ */
+export function selectOnMultiClick(el: TextareaRenderable, after: () => void) {
+  let last = { x: -1, y: -1, at: 0, count: 0 }
+  const host = el as unknown as { onMouseEvent: (event: MouseEvent) => void }
+  const handle = host.onMouseEvent.bind(host)
+  host.onMouseEvent = (event: MouseEvent) => {
+    handle(event)
+    if (event.type !== 'down') return
+    const now = Date.now()
+    const same = event.x === last.x && event.y === last.y && now - last.at < DOUBLE_CLICK_MS
+    const count = same ? last.count + 1 : 1
+    last = { x: event.x, y: event.y, at: now, count }
+    if (count < 2) return
+    const text = el.plainText
+    const at = el.cursorOffset
+    const range = count >= 3 ? lineRangeAt(text, at) : wordRangeAt(text, at)
+    if (range.start >= range.end) return
+    el.setSelection(range.start, range.end)
+    if (count >= 3) last.count = 0
+    after()
   }
 }
 
@@ -2035,6 +2067,7 @@ export function EditorPane(props: EditorPaneProps) {
                 editor = el
                 setEditorEl(el)
                 ignoreScrollOutsideBounds(el)
+                selectOnMultiClick(el, () => scheduleCursorSync())
                 // The gutter paints into a cached buffer and repaints only when
                 // it is dirty or the scroll moved. A file switch reuses this
                 // textarea (setText), and the rewrap lands after the git-signs

--- a/test/selection.test.tsx
+++ b/test/selection.test.tsx
@@ -1,6 +1,8 @@
 import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 
-import { fixture, launch, openFile, settle } from './helpers'
+import { fixture, launch, openFile, press, settle } from './helpers'
 import type { Harness } from './helpers'
 
 interface SelectionHost {
@@ -10,35 +12,90 @@ interface SelectionHost {
 const selected = (t: Harness) =>
   (t as unknown as SelectionHost).renderer?.getSelection()?.getSelectedText() ?? null
 
-async function withOpenFile() {
-  const t = await launch(fixture({ 'a.ts': 'const alpha = 1\nconst beta = 2\n' }))
+const CONTENT = 'const data = []\nconst beta = 2\n'
+
+async function withOpenFile(content = 'const alpha = 1\nconst beta = 2\n') {
+  const dir = fixture({ 'a.ts': content })
+  const t = await launch(dir)
   await openFile(t, 'a.ts')
-  return t
+  return { t, dir }
 }
+
+/** Column of `word` on the editor's first content row. */
+function colOf(t: Harness, word: string) {
+  const row = t.captureCharFrame().split('\n')[1]!
+  return row.indexOf(word)
+}
+
+const save = (t: Harness) => press(t, input => input.pressKey('s', { ctrl: true }))
 
 describe('mouse selection', () => {
   test('dragging in the editor still selects, so Ctrl+C has something to copy', async () => {
-    const t = await withOpenFile()
+    const { t } = await withOpenFile()
     // Found from the frame rather than hard-coded: the editor's first column moves
     // whenever the sidebar is resized or the divider changes width.
-    const row = t.captureCharFrame().split('\n')[1]!
-    const from = row.indexOf('alpha')
+    const from = colOf(t, 'alpha')
     await t.mockMouse.drag(from, 1, from + 5, 1)
     await settle(t)
     expect(selected(t)).toContain('alpha')
   })
 
   test('dragging over the file tree selects nothing', async () => {
-    const t = await withOpenFile()
+    const { t } = await withOpenFile()
     await t.mockMouse.drag(2, 3, 10, 3)
     await settle(t)
     expect(selected(t)).toBeNull()
   })
 
   test('dragging over the tab bar selects nothing', async () => {
-    const t = await withOpenFile()
+    const { t } = await withOpenFile()
     await t.mockMouse.drag(2, 0, 10, 0)
     await settle(t)
     expect(selected(t)).toBeNull()
+  })
+
+  test('double-click selects the word under the cursor', async () => {
+    const { t, dir } = await withOpenFile(CONTENT)
+    const at = colOf(t, 'data')
+    await t.mockMouse.doubleClick(at, 1)
+    await settle(t)
+    // Typing replaces the selection — the same path Ctrl+A and a drag use.
+    await press(t, input => void input.typeText('X'))
+    await save(t)
+    expect(readFileSync(join(dir, 'a.ts'), 'utf8')).toBe('const X = []\nconst beta = 2\n')
+  })
+
+  test('triple-click selects the whole line', async () => {
+    const { t, dir } = await withOpenFile(CONTENT)
+    const at = colOf(t, 'data')
+    await t.mockMouse.click(at, 1)
+    await t.mockMouse.click(at, 1)
+    await t.mockMouse.click(at, 1)
+    await settle(t)
+    await press(t, input => void input.typeText('X'))
+    await save(t)
+    expect(readFileSync(join(dir, 'a.ts'), 'utf8')).toBe('Xconst beta = 2\n')
+  })
+
+  test('a single click does not select the word', async () => {
+    const { t, dir } = await withOpenFile(CONTENT)
+    const at = colOf(t, 'data')
+    await t.mockMouse.click(at, 1)
+    await settle(t)
+    await press(t, input => void input.typeText('X'))
+    await save(t)
+    // Caret lands on a letter of the word; inserting must not wipe `data`.
+    expect(readFileSync(join(dir, 'a.ts'), 'utf8')).toContain('data')
+    expect(readFileSync(join(dir, 'a.ts'), 'utf8')).toContain('X')
+  })
+
+  test('double-click inside a string selects only that word', async () => {
+    const { t, dir } = await withOpenFile('const s = "hello world"\n')
+    const at = colOf(t, 'hello')
+    await t.mockMouse.doubleClick(at, 1)
+    await settle(t)
+    await press(t, input => void input.typeText('X'))
+    await save(t)
+    expect(readFileSync(join(dir, 'a.ts'), 'utf8')).toBe('const s = "X world"\n')
   })
 })

--- a/test/selection.test.tsx
+++ b/test/selection.test.tsx
@@ -98,4 +98,26 @@ describe('mouse selection', () => {
     await save(t)
     expect(readFileSync(join(dir, 'a.ts'), 'utf8')).toBe('const s = "X world"\n')
   })
+
+  test('double-clicking past the end of a line keeps the line break', async () => {
+    const { t, dir } = await withOpenFile()
+    // The caret clamps to the line's `\n`, which is not a token: selecting it
+    // would make the next keystroke pull the following line up.
+    const at = colOf(t, 'const alpha = 1') + 'const alpha = 1'.length + 3
+    await t.mockMouse.doubleClick(at, 1)
+    await settle(t)
+    await press(t, input => void input.typeText('X'))
+    await save(t)
+    expect(readFileSync(join(dir, 'a.ts'), 'utf8')).toBe('const alpha = 1X\nconst beta = 2\n')
+  })
+
+  test('double-clicking a blank line does not eat the blank lines around it', async () => {
+    const { t, dir } = await withOpenFile('const alpha = 1\n\n\n\nconst beta = 2\n')
+    const at = colOf(t, 'const alpha = 1')
+    await t.mockMouse.doubleClick(at, 2)
+    await settle(t)
+    await press(t, input => void input.typeText('X'))
+    await save(t)
+    expect(readFileSync(join(dir, 'a.ts'), 'utf8')).toBe('const alpha = 1\nX\n\n\nconst beta = 2\n')
+  })
 })

--- a/test/words.test.ts
+++ b/test/words.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'bun:test'
+
+import { lineRangeAt, wordRangeAt } from '../src/editor/words'
+
+describe('wordRangeAt', () => {
+  test('selects an identifier under the caret', () => {
+    const text = 'const data = []\n'
+    const at = text.indexOf('data')
+    expect(wordRangeAt(text, at)).toEqual({ start: at, end: at + 4 })
+    expect(wordRangeAt(text, at + 2)).toEqual({ start: at, end: at + 4 })
+  })
+
+  test('treats _ and $ as part of the word', () => {
+    const text = 'const _foo$ = 1\n'
+    const at = text.indexOf('_foo$')
+    expect(wordRangeAt(text, at + 1)).toEqual({ start: at, end: at + 5 })
+  })
+
+  test('selects a run of spaces, not across a newline', () => {
+    const text = 'a  \nb\n'
+    expect(wordRangeAt(text, 1)).toEqual({ start: 1, end: 3 })
+  })
+
+  test('selects a run of punctuation', () => {
+    const text = 'a===b\n'
+    expect(wordRangeAt(text, 2)).toEqual({ start: 1, end: 4 })
+  })
+
+  test('inside a quoted string still selects only the word', () => {
+    const text = 'const s = "hello world"\n'
+    const at = text.indexOf('hello')
+    expect(wordRangeAt(text, at)).toEqual({ start: at, end: at + 5 })
+    expect(wordRangeAt(text, text.indexOf('world'))).toEqual({
+      start: text.indexOf('world'),
+      end: text.indexOf('world') + 5,
+    })
+  })
+
+  test('an empty buffer is a zero range', () => {
+    expect(wordRangeAt('', 0)).toEqual({ start: 0, end: 0 })
+  })
+})
+
+describe('lineRangeAt', () => {
+  test('covers the whole line including its newline', () => {
+    const text = 'const data = []\nnext\n'
+    expect(lineRangeAt(text, text.indexOf('data'))).toEqual({ start: 0, end: 16 })
+  })
+
+  test('the last line without a trailing newline goes to the end', () => {
+    const text = 'only'
+    expect(lineRangeAt(text, 2)).toEqual({ start: 0, end: 4 })
+  })
+
+  test('an empty buffer is a zero range', () => {
+    expect(lineRangeAt('', 0)).toEqual({ start: 0, end: 0 })
+  })
+})

--- a/test/words.test.ts
+++ b/test/words.test.ts
@@ -36,6 +36,23 @@ describe('wordRangeAt', () => {
     })
   })
 
+  test('a run of punctuation stops at the end of the line', () => {
+    const text = 'foo();\nnext\n'
+    const at = text.indexOf('(')
+    expect(wordRangeAt(text, at)).toEqual({ start: at, end: at + 3 })
+  })
+
+  test('a caret on the line terminator selects nothing', () => {
+    const text = 'const a = 1\nconst b = 2\n'
+    const at = text.indexOf('\n')
+    expect(wordRangeAt(text, at)).toEqual({ start: at, end: at })
+  })
+
+  test('a blank line does not select the blank lines around it', () => {
+    const text = 'a\n\n\n\nb\n'
+    expect(wordRangeAt(text, 2)).toEqual({ start: 2, end: 2 })
+  })
+
   test('an empty buffer is a zero range', () => {
     expect(wordRangeAt('', 0)).toEqual({ start: 0, end: 0 })
   })


### PR DESCRIPTION
Added `wordRangeAt` and `lineRangeAt` functions to determine the selection range of words and lines in the editor. These functions support double-click and triple-click selection behavior, enhancing text interaction. Updated `EditorPane` to utilize these functions for mouse click events, and added corresponding tests to ensure correct functionality.