### PR TITLE
fix(editor): scroll viewport on go-to jumps

### DIFF
--- a/src/ui/EditorPane.tsx
+++ b/src/ui/EditorPane.tsx
@@ -1296,16 +1296,22 @@ export function EditorPane(props: EditorPaneProps) {
   }
 
   /**
-   * Land on a file line with the viewport centered on it. The viewport moves
-   * before the caret — the buffer scrolls a moved caret into view by the
-   * smallest amount that shows it, which pins it to an edge without this.
+   * Land on a file line, centering it only when it is not already drawn.
+   *
+   * Viewport first, caret second — the buffer scrolls a moved caret into view by
+   * the smallest amount that shows it, which pins a far jump to an edge with the
+   * code around it off screen. A line that is already on screen is left where it
+   * is: walking search hits or the problems list steps a few lines at a time, and
+   * recentring each of those would slide the text out from under the eye.
    */
   const revealLine = (line: number, col: number) => {
     if (!editor) return
     const viewLine = shownLine(line)
     const row = rowAtLine(viewLine)
     const height = editor.height || editor.editorView.getViewport().height
-    scrollByRows(Math.max(0, row - Math.floor(height / 2)) - editor.scrollY)
+    if (height > 0 && (row < editor.scrollY || row >= editor.scrollY + height)) {
+      scrollToRow(row - Math.floor(height / 2))
+    }
     editor.setCursor(viewLine, col)
     editor.requestRender()
     scheduleCursorSync()

--- a/src/ui/EditorPane.tsx
+++ b/src/ui/EditorPane.tsx
@@ -1239,22 +1239,6 @@ export function EditorPane(props: EditorPaneProps) {
     scrollByRows(Math.max(0, Math.round(row)) - editor.scrollY)
   }
 
-  /**
-   * Land on a file line with the viewport centered on it. The viewport moves
-   * before the caret — the buffer scrolls a moved caret into view by the
-   * smallest amount that shows it, which pins it to an edge without this.
-   */
-  const revealLine = (line: number, col: number) => {
-    if (!editor) return
-    const viewLine = shownLine(line)
-    const row = rowAtLine(viewLine)
-    const height = editor.height || editor.editorView.getViewport().height
-    scrollByRows(Math.max(0, row - Math.floor(height / 2)) - editor.scrollY)
-    editor.setCursor(viewLine, col)
-    editor.requestRender()
-    scheduleCursorSync()
-  }
-
   /** The same, for callers that count in lines rather than in wrapped rows. */
   const scrollTo = (wanted: number) => scrollToRow(rowAtLine(Math.round(wanted)))
 
@@ -1309,6 +1293,22 @@ export function EditorPane(props: EditorPaneProps) {
       syncCursor()
       refreshMenu()
     }, 0)
+  }
+
+  /**
+   * Land on a file line with the viewport centered on it. The viewport moves
+   * before the caret — the buffer scrolls a moved caret into view by the
+   * smallest amount that shows it, which pins it to an edge without this.
+   */
+  const revealLine = (line: number, col: number) => {
+    if (!editor) return
+    const viewLine = shownLine(line)
+    const row = rowAtLine(viewLine)
+    const height = editor.height || editor.editorView.getViewport().height
+    scrollByRows(Math.max(0, row - Math.floor(height / 2)) - editor.scrollY)
+    editor.setCursor(viewLine, col)
+    editor.requestRender()
+    scheduleCursorSync()
   }
 
   /**

--- a/src/ui/EditorPane.tsx
+++ b/src/ui/EditorPane.tsx
@@ -1211,27 +1211,48 @@ export function EditorPane(props: EditorPaneProps) {
   }
 
   /**
-   * Scroll so visual row `row` is the top one.
-   *
-   * `scrollY` is read-only, and moving the caret would be wrong — dragging a
-   * scrollbar must not retarget the cursor. So the move is delivered as the one
-   * scroll input the buffer already accepts: a wheel event, whose delta is in rows.
-   * The coordinates have to land inside the textarea or `ignoreScrollOutsideBounds`
-   * drops it.
+   * Scroll the viewport by `delta` visual rows. The buffer's own `handleScroll`
+   * is used rather than a synthetic wheel event — those are dropped by
+   * `ignoreScrollOutsideBounds` when the textarea's screen bounds are not ready,
+   * which is exactly when a programmatic jump runs.
    */
-  const scrollToRow = (row: number) => {
-    if (!editor) return
-    const delta = Math.max(0, Math.round(row)) - editor.scrollY
-    if (delta === 0) return
-    const host = editor as unknown as { onMouseEvent: (event: unknown) => void }
-    host.onMouseEvent({
-      type: 'scroll',
-      x: editor.x + 1,
-      y: editor.y + 1,
+  const scrollByRows = (delta: number) => {
+    if (!editor || delta === 0) return
+    const host = editor as unknown as {
+      handleScroll: (event: { scroll: { direction: 'up' | 'down'; delta: number } }) => void
+    }
+    host.handleScroll({
       scroll: { direction: delta > 0 ? 'down' : 'up', delta: Math.abs(delta) },
     })
     syncViewport()
     applyWindow()
+  }
+
+  /**
+   * Scroll so visual row `row` is the top one.
+   *
+   * `scrollY` is read-only, and moving the caret would be wrong — dragging a
+   * scrollbar must not retarget the cursor.
+   */
+  const scrollToRow = (row: number) => {
+    if (!editor) return
+    scrollByRows(Math.max(0, Math.round(row)) - editor.scrollY)
+  }
+
+  /**
+   * Land on a file line with the viewport centered on it. The viewport moves
+   * before the caret — the buffer scrolls a moved caret into view by the
+   * smallest amount that shows it, which pins it to an edge without this.
+   */
+  const revealLine = (line: number, col: number) => {
+    if (!editor) return
+    const viewLine = shownLine(line)
+    const row = rowAtLine(viewLine)
+    const height = editor.height || editor.editorView.getViewport().height
+    scrollByRows(Math.max(0, row - Math.floor(height / 2)) - editor.scrollY)
+    editor.setCursor(viewLine, col)
+    editor.requestRender()
+    scheduleCursorSync()
   }
 
   /** The same, for callers that count in lines rather than in wrapped rows. */
@@ -2102,25 +2123,29 @@ export function EditorPane(props: EditorPaneProps) {
 
   // Not deferred: `druk file.ts:42` sets the target before this effect first
   // runs, and a deferred effect would swallow exactly that initial value.
+  // A microtask after the handler still lets a same-tick file switch finish
+  // loading — the path effect resets the buffer to the top before this lands.
   createEffect(
     on(
       () => props.goto?.key,
       () => {
         const target = props.goto
-        if (!target || !editor) return
-        // A jump names a line of the file, and landing on the anchor that hides
-        // it would be a jump to the wrong place — the block opens instead.
-        const view = folded()
-        if (view && (view.display[target.line] ?? 0) < 0) {
-          setFolds(
-            view.folds.filter(fold => target.line <= fold.start || target.line > fold.end),
-            target.line,
-          )
-        }
-        editor.setCursor(shownLine(target.line), target.col)
-        scrollTo(Math.max(0, shownLine(target.line) - Math.floor(editor.height / 2)))
-        editor.focus()
-        scheduleCursorSync()
+        if (!target) return
+        const key = target.key
+        queueMicrotask(() => {
+          if (!editor || props.goto?.key !== key) return
+          // A jump names a line of the file, and landing on the anchor that hides
+          // it would be a jump to the wrong place — the block opens instead.
+          const view = folded()
+          if (view && (view.display[target.line] ?? 0) < 0) {
+            setFolds(
+              view.folds.filter(fold => target.line <= fold.start || target.line > fold.end),
+              target.line,
+            )
+          }
+          revealLine(target.line, target.col)
+          editor.focus()
+        })
       },
     ),
   )

--- a/src/ui/EditorPane.tsx
+++ b/src/ui/EditorPane.tsx
@@ -2118,7 +2118,9 @@ export function EditorPane(props: EditorPaneProps) {
           )
         }
         editor.setCursor(shownLine(target.line), target.col)
+        scrollTo(Math.max(0, shownLine(target.line) - Math.floor(editor.height / 2)))
         editor.focus()
+        scheduleCursorSync()
       },
     ),
   )

--- a/test/goto.test.tsx
+++ b/test/goto.test.tsx
@@ -1,4 +1,4 @@
-import { test } from 'bun:test'
+import { expect, test } from 'bun:test'
 import { join } from 'node:path'
 
 import {
@@ -100,12 +100,13 @@ test('go to definition scrolls the definition into view', async () => {
     { openFile: join(dir, 'a.ts') },
   )
 
-  // Scroll the viewport well past the top — the definition lives in another file
-  // near its start, so without an explicit scroll the caret would move but the
-  // eye would still be reading filler lines.
   await pressTimes(t, 60, input => input.pressArrow('down'))
+  await untilFrame(t, 'const pad59')
+  expect(t.captureCharFrame()).not.toContain('const pad0 = 0')
+
   await runCommand(t, 'Go to definition')
   await untilFrame(t, 'const beta = 1', LSP_WAIT)
+  await untilFrame(t, '// the declaration', LSP_WAIT)
 }, 30_000)
 
 test('go to line scrolls the line into view', async () => {
@@ -114,8 +115,29 @@ test('go to line scrolls the line into view', async () => {
   const t = await launch(dir, {}, {}, { openFile: join(dir, 'big.ts') })
 
   await pressTimes(t, 60, input => input.pressArrow('down'))
+  await untilFrame(t, 'const pad58')
+  expect(t.captureCharFrame()).not.toContain('const target = 0')
+
   await press(t, input => input.pressKey('g', { ctrl: true }))
   await press(t, input => void input.typeText('1'))
   await press(t, input => input.pressEnter())
   await untilFrame(t, 'const target = 0')
+}, 20_000)
+
+test('go to line from deep in the file replaces what is on screen', async () => {
+  const body = Array.from({ length: 120 }, (_, i) => `const line${i} = ${i}`).join('\n')
+  const dir = fixture({ 'big.ts': `${body}\n` })
+  const t = await launch(dir, {}, {}, { openFile: join(dir, 'big.ts') })
+
+  await press(t, input => input.pressKey('g', { ctrl: true }))
+  await press(t, input => void input.typeText('111'))
+  await press(t, input => input.pressEnter())
+  await untilFrame(t, 'const line110 = 110')
+  expect(t.captureCharFrame()).not.toContain('const line0 = 0')
+
+  await press(t, input => input.pressKey('g', { ctrl: true }))
+  await press(t, input => void input.typeText('1'))
+  await press(t, input => input.pressEnter())
+  await untilFrame(t, 'const line0 = 0')
+  expect(t.captureCharFrame()).not.toContain('const line110 = 110')
 }, 20_000)

--- a/test/goto.test.tsx
+++ b/test/goto.test.tsx
@@ -5,6 +5,7 @@ import {
   fixture,
   launch,
   loadMarketExtensions,
+  press,
   pressTimes,
   runCommand,
   untilFrame,
@@ -85,3 +86,36 @@ test('go to definition with LSP off says why nothing happened', async () => {
   await runCommand(t, 'Go to definition')
   await untilFrame(t, 'LSP is off')
 }, 15_000)
+
+test('go to definition scrolls the definition into view', async () => {
+  const filler = Array.from({ length: 80 }, (_, i) => `const pad${i} = ${i}`).join('\n')
+  const dir = fixture({
+    'a.ts': `${filler}\nconst a = beta\n`,
+    'def.ts': '// the declaration\nconst beta = 1\n',
+  })
+  const t = await launch(
+    dir,
+    { lsp: true, lspServers: { typescript: [process.execPath, FAKE], eslint: [], oxlint: [] } },
+    {},
+    { openFile: join(dir, 'a.ts') },
+  )
+
+  // Scroll the viewport well past the top — the definition lives in another file
+  // near its start, so without an explicit scroll the caret would move but the
+  // eye would still be reading filler lines.
+  await pressTimes(t, 60, input => input.pressArrow('down'))
+  await runCommand(t, 'Go to definition')
+  await untilFrame(t, 'const beta = 1', LSP_WAIT)
+}, 30_000)
+
+test('go to line scrolls the line into view', async () => {
+  const filler = Array.from({ length: 80 }, (_, i) => `const pad${i} = ${i}`).join('\n')
+  const dir = fixture({ 'big.ts': `const target = 0\n${filler}\n` })
+  const t = await launch(dir, {}, {}, { openFile: join(dir, 'big.ts') })
+
+  await pressTimes(t, 60, input => input.pressArrow('down'))
+  await press(t, input => input.pressKey('g', { ctrl: true }))
+  await press(t, input => void input.typeText('1'))
+  await press(t, input => input.pressEnter())
+  await untilFrame(t, 'const target = 0')
+}, 20_000)

--- a/test/goto.test.tsx
+++ b/test/goto.test.tsx
@@ -141,3 +141,41 @@ test('go to line from deep in the file replaces what is on screen', async () => 
   await untilFrame(t, 'const line0 = 0')
   expect(t.captureCharFrame()).not.toContain('const line110 = 110')
 }, 20_000)
+
+const numbered = (count: number) =>
+  Array.from({ length: count }, (_, i) => `const line${i} = ${i}`).join('\n')
+
+const gotoLine = async (t: Awaited<ReturnType<typeof launch>>, line: string) => {
+  await press(t, input => input.pressKey('g', { ctrl: true }))
+  await press(t, input => void input.typeText(line))
+  await press(t, input => input.pressEnter())
+}
+
+// The buffer scrolls a moved caret into view by itself, so "the target is on
+// screen" holds without any of this and cannot tell the two apart. What the
+// reveal adds is where it lands: pinned to the bottom edge, only three rows
+// follow it, and the point of jumping to a line is reading what comes after.
+test('a jump off screen centres the target, with the lines after it drawn', async () => {
+  const dir = fixture({ 'big.ts': `${numbered(200)}\n` })
+  const t = await launch(dir, {}, {}, { openFile: join(dir, 'big.ts') })
+
+  await gotoLine(t, '111')
+  await untilFrame(t, 'const line110 = 110')
+  expect(t.captureCharFrame()).toContain('const line116 = 116')
+}, 20_000)
+
+test('a jump to a line already drawn leaves the viewport alone', async () => {
+  const dir = fixture({ 'big.ts': `${numbered(200)}\n` })
+  const t = await launch(dir, {}, {}, { openFile: join(dir, 'big.ts') })
+
+  await gotoLine(t, '100')
+  await untilFrame(t, 'const line99 = 99')
+  const top = 'const line90 = 90'
+  expect(t.captureCharFrame()).toContain(top)
+
+  // Four lines on — well inside what is already drawn, the step walking search
+  // hits or the problems list takes. Recentring here would slide the text.
+  await gotoLine(t, '104')
+  await untilFrame(t, 'Ln 104')
+  expect(t.captureCharFrame()).toContain(top)
+}, 20_000)


### PR DESCRIPTION
## Summary

Go-to jumps (F12, Ctrl+G, search hits, LSP problems, navigation history, `druk file.ts:42`) moved the logical cursor to the right line but often left the viewport unchanged. OpenTUI draws the caret with `visualRow` relative to the viewport, so the status bar could read `Ln 1` while the screen still showed line 111 — the caret clipped to the top of the visible area.

This PR scrolls the viewport before placing the caret:

- **`scrollByRows`** — programmatic scroll via the buffer's `handleScroll`, bypassing synthetic wheel events that `ignoreScrollOutsideBounds` can drop when the textarea has no stable screen coordinates yet.
- **`revealLine`** — centers the target line, scrolls, then sets the cursor (viewport first, caret second).
- **Goto effect** — calls `revealLine` in a microtask so a same-tick file switch can finish loading before the jump lands.

`scrollToRow` now delegates to `scrollByRows` instead of synthesizing wheel events.

## Test plan

- [x] `bun test test/goto.test.tsx`
- [x] `bun test test/scrollbar-drag.test.tsx`
- [x] `bun test test/folding.test.tsx`
- [x] `tsc --noEmit`, `oxlint` and `format:check` on changed files
- [x] Manual: long file → line 111 → Ctrl+G → `1` — line 1 visible on screen
- [x] Manual: F12 to a definition in another file — definition visible and centered