### PR TITLE
feat: add Solidity highlighting and language server

### DIFF
--- a/extensions/index.json
+++ b/extensions/index.json
@@ -633,6 +633,23 @@
       ]
     },
     {
+      "id": "solidity",
+      "name": "Solidity",
+      "version": "1.0.0",
+      "description": "Solidity highlighting and the Nomic Foundation language server.",
+      "provides": {
+        "themes": [],
+        "icons": [],
+        "filetypes": [
+          "solidity"
+        ]
+      },
+      "categories": [
+        "language",
+        "lsp"
+      ]
+    },
+    {
       "id": "sql",
       "name": "SQL",
       "version": "1.0.0",

--- a/extensions/solidity/extension.json
+++ b/extensions/solidity/extension.json
@@ -1,0 +1,27 @@
+{
+  "id": "solidity",
+  "name": "Solidity",
+  "version": "1.0.0",
+  "description": "Solidity highlighting and the Nomic Foundation language server.",
+  "languages": [
+    {
+      "id": "solidity",
+      "lineComment": "//",
+      "grammar": {
+        "vendored": "solidity"
+      },
+      "extensions": [".sol"]
+    }
+  ],
+  "languageServers": [
+    {
+      "id": "solidity",
+      "command": ["nomicfoundation-solidity-language-server", "--stdio"],
+      "filetypes": ["solidity"],
+      "install": {
+        "kind": "npm",
+        "packages": ["@nomicfoundation/solidity-language-server"]
+      }
+    }
+  ]
+}

--- a/src/languages/grammars.ts
+++ b/src/languages/grammars.ts
@@ -27,6 +27,7 @@ import pythonWasm from 'tree-sitter-wasms/out/tree-sitter-python.wasm' with { ty
 import rubyWasm from 'tree-sitter-wasms/out/tree-sitter-ruby.wasm' with { type: 'file' }
 import rustWasm from 'tree-sitter-wasms/out/tree-sitter-rust.wasm' with { type: 'file' }
 import scalaWasm from 'tree-sitter-wasms/out/tree-sitter-scala.wasm' with { type: 'file' }
+import solidityWasm from 'tree-sitter-wasms/out/tree-sitter-solidity.wasm' with { type: 'file' }
 import swiftWasm from 'tree-sitter-wasms/out/tree-sitter-swift.wasm' with { type: 'file' }
 import tomlWasm from 'tree-sitter-wasms/out/tree-sitter-toml.wasm' with { type: 'file' }
 import tsxWasm from 'tree-sitter-wasms/out/tree-sitter-tsx.wasm' with { type: 'file' }
@@ -50,6 +51,7 @@ import pythonQuery from './queries/python.scm' with { type: 'file' }
 import rubyQuery from './queries/ruby.scm' with { type: 'file' }
 import rustQuery from './queries/rust.scm' with { type: 'file' }
 import scalaQuery from './queries/scala.scm' with { type: 'file' }
+import solidityQuery from './queries/solidity.scm' with { type: 'file' }
 import swiftQuery from './queries/swift.scm' with { type: 'file' }
 import tomlQuery from './queries/toml.scm' with { type: 'file' }
 import tsxQuery from './queries/tsx.scm' with { type: 'file' }
@@ -81,6 +83,7 @@ export const GRAMMARS = {
   ruby: { wasm: rubyWasm, query: rubyQuery },
   rust: { wasm: rustWasm, query: rustQuery },
   scala: { wasm: scalaWasm, query: scalaQuery },
+  solidity: { wasm: solidityWasm, query: solidityQuery },
   swift: { wasm: swiftWasm, query: swiftQuery },
   toml: { wasm: tomlWasm, query: tomlQuery },
   tsx: { wasm: tsxWasm, query: tsxQuery },

--- a/src/languages/queries/solidity.scm
+++ b/src/languages/queries/solidity.scm
@@ -1,0 +1,164 @@
+; Identifiers first — equal-specificity captures later in the query win when
+; druk paints overlaps, so definitions and calls must come after.
+; Node names match tree-sitter-wasms' solidity grammar (event_paramater is theirs).
+
+(identifier) @variable
+(yul_identifier) @variable
+
+(pragma_directive) @tag
+(solidity_version_comparison_operator _ @tag)
+
+[
+  (string)
+  (hex_string_literal)
+  (unicode_string_literal)
+  (yul_string_literal)
+] @string
+
+[
+  (number_literal)
+  (yul_decimal_number)
+  (yul_hex_number)
+] @number
+
+(boolean_literal) @boolean
+[
+  (true)
+  (false)
+] @boolean
+
+(comment) @comment
+
+(type_name) @type
+(primitive_type) @type
+(user_defined_type (identifier) @type)
+(payable_conversion_expression "payable" @type)
+
+(struct_declaration name: (identifier) @type)
+(enum_declaration name: (identifier) @type)
+(contract_declaration name: (identifier) @type)
+(library_declaration name: (identifier) @type)
+(interface_declaration name: (identifier) @type)
+(event_definition name: (identifier) @type)
+
+(function_definition name: (identifier) @function)
+(modifier_definition name: (identifier) @function)
+(yul_evm_builtin) @function.builtin
+
+(constructor_definition "constructor" @constructor)
+(fallback_receive_definition "receive" @constructor)
+(fallback_receive_definition "fallback" @constructor)
+
+(struct_member name: (identifier) @property)
+(enum_value) @constant
+
+(emit_statement name: (identifier) @type)
+(modifier_invocation (identifier) @function)
+
+(call_expression function: (identifier) @function)
+(call_expression function: (member_expression property: (identifier) @function.method))
+
+(call_struct_argument name: (_) @property)
+(event_paramater name: (identifier) @variable)
+(parameter name: (identifier) @variable)
+
+(yul_function_call function: (yul_identifier) @function)
+(yul_function_definition . (yul_identifier) @function (yul_identifier) @variable)
+
+(member_expression property: (identifier) @property)
+(struct_field_assignment name: (identifier) @property)
+
+(meta_type_expression "type" @keyword)
+
+[
+  "pragma"
+  "contract"
+  "abstract"
+  "interface"
+  "library"
+  "is"
+  "struct"
+  "enum"
+  "event"
+  "using"
+  "assembly"
+  "emit"
+  "public"
+  "internal"
+  "private"
+  "external"
+  "pure"
+  "view"
+  "payable"
+  "modifier"
+  "memory"
+  "storage"
+  "calldata"
+  "var"
+  "constant"
+  (virtual)
+  (override_specifier)
+  (yul_leave)
+  "for"
+  "while"
+  "do"
+  "break"
+  "continue"
+  "if"
+  "else"
+  "switch"
+  "case"
+  "default"
+  "try"
+  "catch"
+  "return"
+  "returns"
+  "function"
+  "import"
+  "delete"
+  "new"
+] @keyword
+
+(import_directive "as" @keyword)
+(import_directive "from" @keyword)
+(event_paramater "indexed" @keyword)
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+] @punctuation.bracket
+
+[
+  "."
+  ","
+] @punctuation.delimiter
+
+[
+  "&&"
+  "||"
+  ">>"
+  "<<"
+  "&"
+  "^"
+  "|"
+  "+"
+  "-"
+  "*"
+  "/"
+  "%"
+  "**"
+  "<"
+  "<="
+  "=="
+  "!="
+  ">="
+  ">"
+  "!"
+  "~"
+  "++"
+  "--"
+] @operator

--- a/test/solidity.test.ts
+++ b/test/solidity.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from 'bun:test'
+
+import { filetypeForPath, getSyntaxStyle } from '../src/languages/highlight'
+import { loadMarketExtensions } from './helpers'
+import { allSegments } from './syntax'
+
+loadMarketExtensions()
+
+async function painted(source: string) {
+  const segments = await allSegments(source, 'solidity')
+  const lines = source.split('\n')
+  const style = getSyntaxStyle()
+  const byGroup = new Map<number, string[]>()
+  for (const segment of segments) {
+    const text = lines[segment.line]?.slice(segment.start, segment.end) ?? ''
+    if (!text.trim()) continue
+    byGroup.set(segment.styleId, [...(byGroup.get(segment.styleId) ?? []), text.trim()])
+  }
+  return (group: string) => byGroup.get(style.getStyleId(group)!) ?? []
+}
+
+describe('recognising solidity files', () => {
+  test('by extension — OpenTUI does not know .sol', () => {
+    expect(filetypeForPath('Token.sol')).toBe('solidity')
+    expect(filetypeForPath('contracts/Token.sol')).toBe('solidity')
+  })
+})
+
+describe('painting solidity files', () => {
+  const SAMPLE = `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract Token {
+    uint256 public totalSupply;
+
+    event Transfer(address indexed from, address indexed to, uint256 amount);
+
+    constructor(uint256 supply) {
+        totalSupply = supply;
+    }
+
+    function transfer(address to, uint256 amount) public returns (bool) {
+        emit Transfer(msg.sender, to, amount);
+        return true;
+    }
+}
+`
+
+  test('keywords, types, names and strings light up', async () => {
+    const group = await painted(SAMPLE)
+
+    expect(group('keyword')).toEqual(
+      expect.arrayContaining([
+        'pragma',
+        'contract',
+        'public',
+        'event',
+        'function',
+        'returns',
+        'return',
+      ]),
+    )
+    expect(group('type')).toEqual(
+      expect.arrayContaining(['Token', 'uint256', 'address', 'Transfer']),
+    )
+    expect(group('function')).toContain('transfer')
+    expect(group('constructor')).toContain('constructor')
+    expect(group('boolean')).toContain('true')
+    expect(group('comment')[0]).toContain('SPDX-License-Identifier')
+  })
+})


### PR DESCRIPTION
## Summary
- Adds a market extension for Solidity (`.sol`) with tree-sitter highlighting via a vendored `tree-sitter-solidity` grammar and query.
- Wires the Nomic Foundation language server (`@nomicfoundation/solidity-language-server`) with npm auto-install, same pattern as other language extensions.
- Regenerates `extensions/index.json` and covers filetype recognition + highlighting in `test/solidity.test.ts`.

Closes #67.

## Test plan
- [ ] `bun test test/solidity.test.ts test/extensions-repo.test.ts test/cli.test.ts`
- [ ] Install **Solidity** from the extensions panel (or accept the market offer once available on `main`)
- [ ] Open a `.sol` file and confirm keywords/types/functions are highlighted
- [ ] Accept the LSP install prompt (or install `@nomicfoundation/solidity-language-server`) and confirm the server starts for an open `.sol` buffer