### PR TITLE
feat: let the sidebar sit on the left or right

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,8 @@ installer — and run as a CLI.
 
 Features: file tree with bulk file operations and opt-in hiding of dotfiles and
 git-ignored files, the sidebar (Files / Git / Extensions) on the left or the right
-(`sidebarPosition`, settings → Files → Sidebar position), a `▴` in the sidebar
-header that shuts every folder at once
+(`sidebarPosition`, settings → Files → Sidebar position, or palette → View →
+Toggle sidebar position), a `▴` in the sidebar header that shuts every folder at once
 (palette → View → Collapse folders in sidebar, which folds whichever of the two
 sidebar views is up, and the button is drawn only while there is something to fold),
 copy the path of a file to the system clipboard (`Ctrl+Opt+C`, palette → File → Copy

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,9 @@ reconciler on a native Zig core). Shipped as a standalone binary — npm, Homebr
 installer — and run as a CLI.
 
 Features: file tree with bulk file operations and opt-in hiding of dotfiles and
-git-ignored files, a `▴` in the sidebar header that shuts every folder at once
+git-ignored files, the sidebar (Files / Git / Extensions) on the left or the right
+(`sidebarPosition`, settings → Files → Sidebar position), a `▴` in the sidebar
+header that shuts every folder at once
 (palette → View → Collapse folders in sidebar, which folds whichever of the two
 sidebar views is up, and the button is drawn only while there is something to fold),
 copy the path of a file to the system clipboard (`Ctrl+Opt+C`, palette → File → Copy

--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ instead of breaking startup.
 | `wrap` | `true` | set `false` to keep each line on one row — the tail of a long line is then reached by moving the cursor into it (palette → View → Toggle word wrap) |
 | `vim` | `false` | normal / insert / visual modes, `hjkl w b 0 $ gg G`, counts, `i a o`, `x dd dw cw`, `v` + `d y c`, `yy p P`, `u` / `Ctrl+R` |
 | `sidebarWidth` | `"auto"` | a quarter of the window, or pin 15–80 columns |
+| `sidebarPosition` | `"left"` | `left` or `right` — which side of the editor the Files / Git / Extensions sidebar sits on |
 | `trimOnSave` | `false` | on save: strip trailing spaces and end the file with one newline |
 | `autoSaveOnBlur` | `true` | save unsaved tabs when switching tabs or when the terminal window loses focus |
 | `showDotfiles` | `true` | set `false` to hide dotfiles in the file tree |

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ instead of breaking startup.
 | `wrap` | `true` | set `false` to keep each line on one row — the tail of a long line is then reached by moving the cursor into it (palette → View → Toggle word wrap) |
 | `vim` | `false` | normal / insert / visual modes, `hjkl w b 0 $ gg G`, counts, `i a o`, `x dd dw cw`, `v` + `d y c`, `yy p P`, `u` / `Ctrl+R` |
 | `sidebarWidth` | `"auto"` | a quarter of the window, or pin 15–80 columns |
-| `sidebarPosition` | `"left"` | `left` or `right` — which side of the editor the Files / Git / Extensions sidebar sits on |
+| `sidebarPosition` | `"left"` | `left` or `right` — which side of the editor the Files / Git / Extensions sidebar sits on (palette → View → Toggle sidebar position) |
 | `trimOnSave` | `false` | on save: strip trailing spaces and end the file with one newline |
 | `autoSaveOnBlur` | `true` | save unsaved tabs when switching tabs or when the terminal window loses focus |
 | `showDotfiles` | `true` | set `false` to hide dotfiles in the file tree |

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -59,8 +59,9 @@ import { createStatus, READY } from './status'
 import { createTree, hiddenNodes } from './tree'
 import { CLASH_CHANGED, CLASH_DELETED, createWorkspace, restoreWorkspace } from './workspace'
 
-/** The divider draws its own left edge; a box border is how it spans the height. */
+/** The divider draws its edge against the sidebar; a box border spans the height. */
 const BORDER_LEFT: BorderSides[] = ['left']
+const BORDER_RIGHT: BorderSides[] = ['right']
 
 /** Bounds on the drawn part of the divider: shorter reads as dirt, longer as chrome. */
 const GRIP_MIN = 3
@@ -714,7 +715,7 @@ export function App(props: {
               height={gripHeight()}
               flexShrink={0}
               backgroundColor={ui.bg}
-              border={BORDER_LEFT}
+              border={config.sidebarPosition === 'right' ? BORDER_RIGHT : BORDER_LEFT}
               borderColor={resizing() ? ui.accent : ui.border}
               onMouseDown={startResize}
             />

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -59,9 +59,10 @@ import { createStatus, READY } from './status'
 import { createTree, hiddenNodes } from './tree'
 import { CLASH_CHANGED, CLASH_DELETED, createWorkspace, restoreWorkspace } from './workspace'
 
-/** The divider draws its edge against the sidebar; a box border spans the height. */
+/** The divider draws its own left edge; a box border is how it spans the height.
+    One side only, and the grip is one column wide, so the border lands on that
+    column whichever side names it — there is no right-hand variant to add. */
 const BORDER_LEFT: BorderSides[] = ['left']
-const BORDER_RIGHT: BorderSides[] = ['right']
 
 /** Bounds on the drawn part of the divider: shorter reads as dirt, longer as chrome. */
 const GRIP_MIN = 3
@@ -715,7 +716,7 @@ export function App(props: {
               height={gripHeight()}
               flexShrink={0}
               backgroundColor={ui.bg}
-              border={config.sidebarPosition === 'right' ? BORDER_RIGHT : BORDER_LEFT}
+              border={BORDER_LEFT}
               borderColor={resizing() ? ui.accent : ui.border}
               onMouseDown={startResize}
             />

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -296,9 +296,17 @@ export function App(props: {
   const gripHeight = () =>
     Math.max(GRIP_MIN, Math.min(GRIP_MAX, Math.round((dimensions().height - 2) / 5)))
 
+  /**
+   * On the left the sidebar starts at column 0, so the pointer's x is the width
+   * (the divider sits at that column). On the right the divider is at x and the
+   * sidebar fills what follows, so the width is everything after the divider.
+   */
+  const sidebarWidthFromPointer = (x: number) =>
+    config.sidebarPosition === 'right' ? dimensions().width - x - 1 : x
+
   const startResize = (event: MouseEvent) => {
     setResizing(true)
-    settings.resizeSidebar(event.x)
+    settings.resizeSidebar(sidebarWidthFromPointer(event.x))
   }
 
   /** Worst problem per line of the active file: the gutter dot and inline text. */
@@ -551,12 +559,13 @@ export function App(props: {
       />
       {/* Drag capture lives on the row, not the divider: the pointer leaves a
           one-column target immediately, and each drag event is delivered to
-          whatever sits under it. */}
+          whatever sits under it. `row-reverse` puts the same children on the
+          right without duplicating the sidebar tree. */}
       <box
-        flexDirection="row"
+        flexDirection={config.sidebarPosition === 'right' ? 'row-reverse' : 'row'}
         flexGrow={1}
         onMouseDrag={(event: MouseEvent) => {
-          if (resizing()) settings.resizeSidebar(event.x)
+          if (resizing()) settings.resizeSidebar(sidebarWidthFromPointer(event.x))
         }}
         onMouseDragEnd={() => setResizing(false)}
         onMouseUp={() => setResizing(false)}
@@ -689,9 +698,8 @@ export function App(props: {
               rule the whole way down is a second vertical line beside the
               editor's gutter and reads as chrome rather than as a hint. The
               accent while dragging says the grab took. Painted in `bg`, not
-              `panelBg` — the sidebar's right edge is found by where panel colour
-              stops, and the resize tests measure exactly that. The sidebar
-              starts at column 0, so the pointer's x is the width asked for. */}
+              `panelBg` — on the left the sidebar's right edge is found by where
+              panel colour stops, and the resize tests measure exactly that. */}
           <box
             width={1}
             flexShrink={0}

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -414,6 +414,7 @@ export function createCommands(ctx: AppContext) {
     previewIcons: settings.previewIcons,
     restoreIcons: settings.restoreIcons,
     toggleWrap: settings.toggleWrap,
+    toggleSidebarPosition: settings.toggleSidebarPosition,
     lineOp: editor.requestLineOp,
     foldOp: editor.requestFoldOp,
     triggerCompletion: editor.requestCompletion,

--- a/src/app/commands.ts
+++ b/src/app/commands.ts
@@ -68,6 +68,7 @@ export interface CommandActions {
   togglePreview: () => void
   toggleMarkdown: () => void
   toggleWrap: () => void
+  toggleSidebarPosition: () => void
   setTheme: (name: ThemeName) => void
   previewTheme: (name: ThemeName) => void
   restoreTheme: () => void
@@ -377,6 +378,11 @@ export function buildCommands(actions: CommandActions, ctx: CommandContext): Com
           id: 'view.wrap',
           label: 'Toggle word wrap',
           run: actions.toggleWrap,
+        },
+        {
+          id: 'view.sidebarPosition',
+          label: 'Toggle sidebar position',
+          run: actions.toggleSidebarPosition,
         },
         {
           id: 'view.focus',

--- a/src/app/keyboard.ts
+++ b/src/app/keyboard.ts
@@ -91,6 +91,7 @@ export function installKeyboard(ctx: AppContext, actions: CommandActions) {
     'view.collapse': actions.collapseSidebar,
     'view.markdown': workspace.toggleRendered,
     'view.wrap': actions.toggleWrap,
+    'view.sidebarPosition': actions.toggleSidebarPosition,
     'view.preview': actions.togglePreview,
     'view.focus': actions.toggleFocus,
     'git.diffFile': actions.gitDiffFile,

--- a/src/app/keymap.ts
+++ b/src/app/keymap.ts
@@ -96,6 +96,7 @@ export const BINDABLE: Bindable[] = [
     defaults: [`Ctrl+${ALT}+M`],
   },
   { id: 'view.wrap', label: 'Toggle word wrap', defaults: [] },
+  { id: 'view.sidebarPosition', label: 'Toggle sidebar position', defaults: [] },
   // No default chord: the key for this is Space in the tree, which the global
   // keymap cannot hold — a bare key here would be typing the editor never sees.
   { id: 'view.preview', label: 'Preview file (no tab)', defaults: [] },

--- a/src/app/settings.ts
+++ b/src/app/settings.ts
@@ -13,7 +13,6 @@ import {
   sidebarColumns,
   SIDEBAR_MIN,
   SIDEBAR_MAX,
-  SIDEBAR_POSITIONS,
 } from '../core/config'
 import type { Config, ConfigScope, SidebarPosition } from '../core/config'
 import { FORGE_KINDS } from '../core/forge'
@@ -818,19 +817,15 @@ export function createSettings(deps: {
       },
     },
     {
+      // Two values: a list to choose between them is more ceremony than the
+      // flip is worth, so this stays a step like the booleans above.
       section: 'Files',
       key: 'sidebarPosition',
       label: 'Sidebar position',
       value: view().sidebarPosition,
       cycle: toggleSidebarPosition,
-      select: {
-        options: [...SIDEBAR_POSITIONS],
-        pick: at => applySidebarPosition(SIDEBAR_POSITIONS[at]!),
-      },
     },
     {
-      // Two values: a list to choose between them is more ceremony than the
-      // flip is worth, so this stays a step like the booleans above.
       section: 'Git',
       key: 'diffView',
       label: 'Diff layout',

--- a/src/app/settings.ts
+++ b/src/app/settings.ts
@@ -13,8 +13,9 @@ import {
   sidebarColumns,
   SIDEBAR_MIN,
   SIDEBAR_MAX,
+  SIDEBAR_POSITIONS,
 } from '../core/config'
-import type { Config, ConfigScope } from '../core/config'
+import type { Config, ConfigScope, SidebarPosition } from '../core/config'
 import { FORGE_KINDS } from '../core/forge'
 import type { ForgeSetting } from '../core/forge'
 import { FILE_TOKEN } from '../core/format'
@@ -621,6 +622,14 @@ export function createSettings(deps: {
     status.say(`Sidebar width: ${view().sidebarWidth}`)
   }
 
+  const applySidebarPosition = (position: SidebarPosition) => {
+    patchConfig({ sidebarPosition: position })
+    status.say(`Sidebar on the ${config.sidebarPosition}`)
+  }
+
+  const toggleSidebarPosition = () =>
+    applySidebarPosition(view().sidebarPosition === 'left' ? 'right' : 'left')
+
   /** The rows as this module declares them: what the page draws, plus the key it edits. */
   type RowSpec = Omit<SettingRow, 'local' | 'clear'> & { key: keyof Config }
 
@@ -806,6 +815,17 @@ export function createSettings(deps: {
           '"auto" takes a share of the terminal',
         ],
         apply: values => applySidebarWidth(values[0] ?? ''),
+      },
+    },
+    {
+      section: 'Files',
+      key: 'sidebarPosition',
+      label: 'Sidebar position',
+      value: view().sidebarPosition,
+      cycle: toggleSidebarPosition,
+      select: {
+        options: [...SIDEBAR_POSITIONS],
+        pick: at => applySidebarPosition(SIDEBAR_POSITIONS[at]!),
       },
     },
     {
@@ -1059,6 +1079,8 @@ export function createSettings(deps: {
     setFormatter,
     setServerCommand,
     applySidebarWidth,
+    applySidebarPosition,
+    toggleSidebarPosition,
     rows,
     treeWidth,
     resizeSidebar,

--- a/src/app/settings.ts
+++ b/src/app/settings.ts
@@ -623,7 +623,7 @@ export function createSettings(deps: {
 
   const applySidebarPosition = (position: SidebarPosition) => {
     patchConfig({ sidebarPosition: position })
-    status.say(`Sidebar on the ${config.sidebarPosition}`)
+    status.say(`Sidebar position: ${view().sidebarPosition}`)
   }
 
   const toggleSidebarPosition = () =>
@@ -817,8 +817,6 @@ export function createSettings(deps: {
       },
     },
     {
-      // Two values: a list to choose between them is more ceremony than the
-      // flip is worth, so this stays a step like the booleans above.
       section: 'Files',
       key: 'sidebarPosition',
       label: 'Sidebar position',
@@ -826,6 +824,8 @@ export function createSettings(deps: {
       cycle: toggleSidebarPosition,
     },
     {
+      // Two values: a list to choose between them is more ceremony than the
+      // flip is worth, so this stays a step like the booleans above.
       section: 'Git',
       key: 'diffView',
       label: 'Diff layout',

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -68,6 +68,9 @@ export function sidebarColumns(width: number | 'auto', terminalWidth: number): n
 export const CURSOR_STYLES = ['block', 'line', 'underline'] as const
 export type CursorStyle = (typeof CURSOR_STYLES)[number]
 
+export const SIDEBAR_POSITIONS = ['left', 'right'] as const
+export type SidebarPosition = (typeof SIDEBAR_POSITIONS)[number]
+
 export interface Config {
   /** Color scheme id — see src/themes. */
   theme: ThemeName
@@ -120,6 +123,8 @@ export interface Config {
    * Resizing with `[` / `]` or by dragging the divider pins an explicit number.
    */
   sidebarWidth: number | 'auto'
+  /** Which side of the editor the sidebar (Files / Git / Extensions) sits on. */
+  sidebarPosition: SidebarPosition
   /** Version whose update notice was dismissed; suppresses the banner for it. */
   skipUpdate: string
   /** On save: strip trailing spaces and end the file with one newline. */
@@ -237,6 +242,7 @@ export const DEFAULTS: Config = {
   wrap: true,
   tabSize: 2,
   sidebarWidth: 'auto',
+  sidebarPosition: 'left',
   skipUpdate: '',
   trimOnSave: false,
   formatOnSave: false,
@@ -322,6 +328,7 @@ const VALIDATORS: { [K in keyof Config]: Validator<K> } = {
       ? Math.floor(raw)
       : undefined
   },
+  sidebarPosition: among(...SIDEBAR_POSITIONS),
   skipUpdate: text,
   trimOnSave: bool,
   formatOnSave: bool,

--- a/test/settings-edit.test.tsx
+++ b/test/settings-edit.test.tsx
@@ -232,6 +232,24 @@ test(
 )
 
 test(
+  'sidebar position flips between left and right from the page',
+  async () => {
+    const t = await launch(fixture(PROJECT))
+    await runCommand(t, 'Settings')
+    await gotoRow(t, 'Sidebar position')
+    expect(t.captureCharFrame()).toMatch(/Sidebar position\s+left/)
+
+    await press(t, i => i.pressArrow('right'))
+    expect(saved().sidebarPosition).toBe('right')
+    expect(t.captureCharFrame()).toMatch(/Sidebar position\s+right/)
+
+    await press(t, i => i.pressArrow('right'))
+    expect(saved().sidebarPosition).toBe('left')
+  },
+  LATE_ROW,
+)
+
+test(
   'a server command is overridden and restored from the page',
   async () => {
     const t = await launch(fixture(PROJECT))

--- a/test/sidebar-resize.test.tsx
+++ b/test/sidebar-resize.test.tsx
@@ -136,6 +136,71 @@ describe('resizing the sidebar', () => {
   })
 })
 
+/**
+ * Column the tree starts at when it sits on the right — where panel colour
+ * begins after the editor and runs to the edge. The tab strip's own cells are
+ * interrupted by accent/bar colours, so only a solid run to the end counts.
+ */
+function sidebarStart(t: Harness): number {
+  const frame = t.captureSpans() as unknown as { lines: { spans: Span[] }[] }
+  const panel = ui.panelBg.toLowerCase()
+  for (const line of frame.lines) {
+    let column = 0
+    let start = -1
+    for (const span of line.spans) {
+      if (hex(span.bg) === panel) {
+        if (start < 0) start = column
+      } else if (start >= 0) {
+        start = -1
+      }
+      column += span.text.length
+    }
+    if (start > 0) return start
+  }
+  return -1
+}
+
+describe('sidebar on the right', () => {
+  test('the panel sits at the terminal edge, past the editor', async () => {
+    const t = await launch(fixture(PROJECT), { sidebarPosition: 'right', sidebarWidth: 30 })
+    // 80-column terminal: editor, one-column divider, then 30 of sidebar.
+    expect(sidebarStart(t)).toBe(50)
+    // Left side is not the tree — the first column is the editor background.
+    expect(dividerAt(t)).toBe(-1)
+  })
+
+  test('dragging the divider sets the width from the right edge', async () => {
+    const t = await launch(fixture(PROJECT), { sidebarPosition: 'right', sidebarWidth: 30 })
+    expect(sidebarStart(t)).toBe(50)
+
+    // Pointer at column 39 → width = 80 − 39 − 1 = 40, sidebar starts at 40.
+    await t.mockMouse.drag(sidebarStart(t) - 1, 5, 39, 5)
+    await settle(t)
+    expect(sidebarStart(t)).toBe(40)
+
+    // Pointer at column 57 → width = 22, sidebar starts at 58.
+    await t.mockMouse.drag(sidebarStart(t) - 1, 5, 57, 5)
+    await settle(t)
+    expect(sidebarStart(t)).toBe(58)
+  })
+
+  test('] and [ still widen and narrow from the tree', async () => {
+    const t = await launch(fixture(PROJECT), { sidebarPosition: 'right', sidebarWidth: 30 })
+    const start = sidebarStart(t)
+
+    await press(t, input => void input.typeText(']'))
+    await settle(t)
+    // Wider sidebar starts further left.
+    const wider = sidebarStart(t)
+    expect(wider).toBeLessThan(start)
+
+    await press(t, input => void input.typeText('['))
+    await press(t, input => void input.typeText('['))
+    await settle(t)
+    expect(sidebarStart(t)).toBeGreaterThan(wider)
+  })
+})
+
 describe('what must not move when the sidebar does', () => {
   test('the tab bar is unaffected — it spans the terminal, above the tree', async () => {
     const files: Record<string, string> = {}
@@ -162,6 +227,7 @@ describe('what must not move when the sidebar does', () => {
     git('init', '-q', '-b', 'main')
     git('config', 'user.email', 't@e.com')
     git('config', 'user.name', 'T')
+    git('config', 'commit.gpgsign', 'false')
     writeFileSync(join(dir, 'tracked.ts'), 'const a = 1\n')
     writeFileSync(join(dir, 'a-much-longer-name.ts'), 'const b = 2\n')
     git('add', '.')

--- a/test/sidebar-resize.test.tsx
+++ b/test/sidebar-resize.test.tsx
@@ -6,7 +6,7 @@ import { join } from 'node:path'
 
 import { SIDEBAR_MIN } from '../src/core/config'
 import { ui } from '../src/themes'
-import { fixture, launch, openFile, press, settle } from './helpers'
+import { fixture, launch, openFile, press, pressEscape, runCommand, settle } from './helpers'
 import type { Harness } from './helpers'
 
 const PROJECT = { 'alpha.ts': 'const a = 1\n', 'beta.ts': 'const b = 2\n' }
@@ -167,6 +167,46 @@ describe('sidebar on the right', () => {
     expect(sidebarStart(t)).toBe(50)
     // Left side is not the tree — the first column is the editor background.
     expect(dividerAt(t)).toBe(-1)
+  })
+
+  test('the palette command moves it to the other edge and back', async () => {
+    const t = await launch(fixture(PROJECT), { sidebarWidth: 30 })
+    expect(dividerAt(t)).toBe(30)
+    expect(sidebarStart(t)).toBe(-1)
+
+    await runCommand(t, 'Toggle sidebar position')
+    expect(dividerAt(t)).toBe(-1)
+    expect(sidebarStart(t)).toBe(50)
+
+    await runCommand(t, 'Toggle sidebar position')
+    expect(dividerAt(t)).toBe(30)
+    expect(sidebarStart(t)).toBe(-1)
+  })
+
+  test('flipping the settings row moves the panel on screen', async () => {
+    const t = await launch(fixture(PROJECT), { sidebarWidth: 30 })
+    expect(dividerAt(t)).toBe(30)
+
+    await runCommand(t, 'Settings')
+    let onRow = false
+    for (let step = 0; step < 40; step++) {
+      const row = t
+        .captureCharFrame()
+        .split('\n')
+        .find(line => line.includes('Sidebar position'))
+      if (row?.includes('▌')) {
+        onRow = true
+        break
+      }
+      await press(t, i => i.pressArrow('down'))
+    }
+    expect(onRow).toBe(true)
+    await press(t, i => i.pressArrow('right'))
+    await pressEscape(t)
+    await settle(t)
+
+    expect(dividerAt(t)).toBe(-1)
+    expect(sidebarStart(t)).toBe(50)
   })
 
   test('dragging the divider sets the width from the right edge', async () => {


### PR DESCRIPTION
## Summary
- Add `sidebarPosition` (`left` / `right`) so the Files / Git / Extensions sidebar can sit on either side of the editor — settings → Files → Sidebar position, or palette → View → Toggle sidebar position
- Keep drag-resize and `[` / `]` working when the sidebar is on the right (`row-reverse` layout; width from the pointer is `terminalWidth − x − 1`)
- Draw the divider grip against the panel on both sides (`BORDER_RIGHT` when the sidebar is on the right)
- Cover persistence, live layout from the settings row and the palette command, and right-side drag/`[`/`]` in tests; document in README and AGENTS.md

## Test plan
- [ ] Settings → Files → Sidebar position → switch to `right`, confirm Files/Git/Ext move
- [ ] Palette → View → Toggle sidebar position moves the panel and back
- [ ] Drag the divider on the right: wider/narrower follow the pointer; grip stays against the panel
- [ ] From the tree, `]` widens and `[` narrows on both sides
- [ ] Switch back to `left` and confirm the previous layout
- [ ] `bun test test/sidebar-resize.test.tsx test/settings-edit.test.tsx test/keymap.test.ts`