### PR TITLE
fix(diff): stop TextBufferView crash when a commit closes the page

### DIFF
--- a/src/ui/DiffView.tsx
+++ b/src/ui/DiffView.tsx
@@ -1,6 +1,6 @@
 import type { DiffRenderable, KeyEvent, TreeSitterClient } from '@opentui/core'
 import { useTerminalDimensions } from '@opentui/solid'
-import { createEffect, createMemo, createSignal, on, onMount, Show } from 'solid-js'
+import { createEffect, createMemo, createSignal, on, onCleanup, onMount, Show } from 'solid-js'
 
 import { unifiedDiff } from '../core/diff'
 import type { UnifiedDiff } from '../core/diff'
@@ -235,6 +235,16 @@ export function DiffView(props: DiffViewProps) {
   onMount(() => void highlightClient().then(c => setClient(c)))
 
   let pane: DiffRenderable | undefined
+  // A deferred attach must not touch panes after the page (or its `<diff>`) is
+  // gone: refreshDiff / setDiff(null) destroy the TextBufferView, and assigning
+  // onHighlight or reading scroll metrics then throws "TextBufferView is destroyed"
+  // (issue #70). Clear the timer on cleanup and skip when the host is already dead.
+  let diffAlive = true
+  let attachTimer: ReturnType<typeof setTimeout> | undefined
+  onCleanup(() => {
+    diffAlive = false
+    if (attachTimer !== undefined) clearTimeout(attachTimer)
+  })
 
   const sides = () => {
     const host = pane as unknown as DiffSides | undefined
@@ -242,6 +252,9 @@ export function DiffView(props: DiffViewProps) {
       (side): side is CodePane => side != null,
     )
   }
+
+  const paneDestroyed = (code: CodePane | null | undefined) =>
+    !!(code as { isDestroyed?: boolean } | null | undefined)?.isDestroyed
 
   /**
    * Everything derived from one change: its patch, and the highlight pass each
@@ -435,7 +448,7 @@ export function DiffView(props: DiffViewProps) {
       ['left', host.leftCodeRenderable],
       ['right', host.rightCodeRenderable],
     ] as const) {
-      if (!code) continue
+      if (!code || paneDestroyed(code)) continue
       // Before the first layout the pane has no width yet; half the pane's own
       // columns overshoots by the gutter, which `wrapMode="none"` clips away.
       const bar = HATCH.repeat(Math.max(1, code.width || Math.ceil(props.width / 2)))
@@ -463,25 +476,26 @@ export function DiffView(props: DiffViewProps) {
     on([current, mode, client, () => props.width, () => ui.dim, () => ui.solidBg], () => {
       const highlighter = current().highlighter
       const view = mode() === 'split' ? 'split' : 'unified'
-      setTimeout(() => {
-        const host = pane as unknown as DiffSides | undefined
-        if (!host) return
+      if (attachTimer !== undefined) clearTimeout(attachTimer)
+      attachTimer = setTimeout(() => {
+        attachTimer = undefined
+        const host = pane as unknown as (DiffSides & { isDestroyed?: boolean }) | undefined
+        const left = host?.leftCodeRenderable
+        const right = host?.rightCodeRenderable
+        if (!diffAlive || !host || host.isDestroyed) return
+        if (paneDestroyed(left) || paneDestroyed(right)) return
         if (plain()) {
           // The prop already keeps the filetype off the renderable, but a pane
           // reused from the previous change keeps the one it had (see
           // NO_HIGHLIGHTS) — clearing it here is what stops the parse itself.
-          for (const code of [host.leftCodeRenderable, host.rightCodeRenderable]) {
+          for (const code of [left, right]) {
             if (!code) continue
             code.filetype = undefined
             code.onHighlight = NO_HIGHLIGHTS
           }
         } else {
-          if (host.leftCodeRenderable) {
-            host.leftCodeRenderable.onHighlight = highlighter('left', view)
-          }
-          if (host.rightCodeRenderable) {
-            host.rightCodeRenderable.onHighlight = highlighter('right', view)
-          }
+          if (left) left.onHighlight = highlighter('left', view)
+          if (right) right.onHighlight = highlighter('right', view)
         }
         paintHatch(host, view)
       }, 0)
@@ -489,11 +503,15 @@ export function DiffView(props: DiffViewProps) {
   )
   const scroll = (delta: number) => {
     for (const side of sides()) {
+      if (paneDestroyed(side)) continue
       side.scrollY = Math.max(0, Math.min(side.maxScrollY, side.scrollY + delta))
     }
   }
   const scrollTo = (row: number) => {
-    for (const side of sides()) side.scrollY = Math.max(0, Math.min(side.maxScrollY, row))
+    for (const side of sides()) {
+      if (paneDestroyed(side)) continue
+      side.scrollY = Math.max(0, Math.min(side.maxScrollY, row))
+    }
   }
 
   // Keyed on the path, not the file: a refresh rebuilds the same change on every

--- a/src/ui/DiffView.tsx
+++ b/src/ui/DiffView.tsx
@@ -141,6 +141,8 @@ type OnHighlight = (
 interface CodePane {
   scrollY: number
   maxScrollY: number
+  /** Every accessor below throws once this is true (see `livePane`). */
+  isDestroyed: boolean
   /** Columns the code itself owns — the side minus its gutter. */
   width: number
   content: string
@@ -235,26 +237,31 @@ export function DiffView(props: DiffViewProps) {
   onMount(() => void highlightClient().then(c => setClient(c)))
 
   let pane: DiffRenderable | undefined
-  // A deferred attach must not touch panes after the page (or its `<diff>`) is
-  // gone: refreshDiff / setDiff(null) destroy the TextBufferView, and assigning
-  // onHighlight or reading scroll metrics then throws "TextBufferView is destroyed"
-  // (issue #70). Clear the timer on cleanup and skip when the host is already dead.
-  let diffAlive = true
-  let attachTimer: ReturnType<typeof setTimeout> | undefined
-  onCleanup(() => {
-    diffAlive = false
-    if (attachTimer !== undefined) clearTimeout(attachTimer)
-  })
 
-  const sides = () => {
-    const host = pane as unknown as DiffSides | undefined
-    return [host?.leftCodeRenderable, host?.rightCodeRenderable].filter(
-      (side): side is CodePane => side != null,
-    )
+  /** Nothing may fire the deferred attach after the page is gone (issue #70). */
+  let attachTimer: ReturnType<typeof setTimeout> | undefined
+  onCleanup(() => clearTimeout(attachTimer))
+
+  /**
+   * The `<diff>` on screen, or nothing.
+   *
+   * The ref is never called back when the element goes away, and the reconciler
+   * destroys a removed renderable a tick later — so a page that falls back to
+   * "No changes in this file" leaves `pane` pointing at a corpse whose every
+   * accessor throws "TextBufferView is destroyed". Paging from one such change
+   * to another is what reaches it: nothing has replaced the ref in between.
+   */
+  const livePane = () => {
+    if (pane?.isDestroyed) pane = undefined
+    return pane
   }
 
-  const paneDestroyed = (code: CodePane | null | undefined) =>
-    !!(code as { isDestroyed?: boolean } | null | undefined)?.isDestroyed
+  const sides = () => {
+    const host = livePane() as unknown as DiffSides | undefined
+    return [host?.leftCodeRenderable, host?.rightCodeRenderable].filter(
+      (side): side is CodePane => side != null && !side.isDestroyed,
+    )
+  }
 
   /**
    * Everything derived from one change: its patch, and the highlight pass each
@@ -448,7 +455,7 @@ export function DiffView(props: DiffViewProps) {
       ['left', host.leftCodeRenderable],
       ['right', host.rightCodeRenderable],
     ] as const) {
-      if (!code || paneDestroyed(code)) continue
+      if (!code || code.isDestroyed) continue
       // Before the first layout the pane has no width yet; half the pane's own
       // columns overshoots by the gutter, which `wrapMode="none"` clips away.
       const bar = HATCH.repeat(Math.max(1, code.width || Math.ceil(props.width / 2)))
@@ -476,26 +483,29 @@ export function DiffView(props: DiffViewProps) {
     on([current, mode, client, () => props.width, () => ui.dim, () => ui.solidBg], () => {
       const highlighter = current().highlighter
       const view = mode() === 'split' ? 'split' : 'unified'
-      if (attachTimer !== undefined) clearTimeout(attachTimer)
+      // Only the last of a burst has the state worth applying, and an earlier
+      // one would run against panes the rebuild has already replaced.
+      clearTimeout(attachTimer)
       attachTimer = setTimeout(() => {
         attachTimer = undefined
-        const host = pane as unknown as (DiffSides & { isDestroyed?: boolean }) | undefined
-        const left = host?.leftCodeRenderable
-        const right = host?.rightCodeRenderable
-        if (!diffAlive || !host || host.isDestroyed) return
-        if (paneDestroyed(left) || paneDestroyed(right)) return
-        if (plain()) {
-          // The prop already keeps the filetype off the renderable, but a pane
-          // reused from the previous change keeps the one it had (see
-          // NO_HIGHLIGHTS) — clearing it here is what stops the parse itself.
-          for (const code of [left, right]) {
-            if (!code) continue
+        // A tick later, so the page may have fallen back to "No changes" and
+        // taken its panes with it (see `livePane`).
+        const host = livePane() as unknown as DiffSides | undefined
+        if (!host) return
+        for (const [which, code] of [
+          ['left', host.leftCodeRenderable],
+          ['right', host.rightCodeRenderable],
+        ] as const) {
+          if (!code || code.isDestroyed) continue
+          if (plain()) {
+            // The prop already keeps the filetype off the renderable, but a pane
+            // reused from the previous change keeps the one it had (see
+            // NO_HIGHLIGHTS) — clearing it here is what stops the parse itself.
             code.filetype = undefined
             code.onHighlight = NO_HIGHLIGHTS
+          } else {
+            code.onHighlight = highlighter(which, view)
           }
-        } else {
-          if (left) left.onHighlight = highlighter('left', view)
-          if (right) right.onHighlight = highlighter('right', view)
         }
         paintHatch(host, view)
       }, 0)
@@ -503,15 +513,11 @@ export function DiffView(props: DiffViewProps) {
   )
   const scroll = (delta: number) => {
     for (const side of sides()) {
-      if (paneDestroyed(side)) continue
       side.scrollY = Math.max(0, Math.min(side.maxScrollY, side.scrollY + delta))
     }
   }
   const scrollTo = (row: number) => {
-    for (const side of sides()) {
-      if (paneDestroyed(side)) continue
-      side.scrollY = Math.max(0, Math.min(side.maxScrollY, row))
-    }
+    for (const side of sides()) side.scrollY = Math.max(0, Math.min(side.maxScrollY, row))
   }
 
   // Keyed on the path, not the file: a refresh rebuilds the same change on every

--- a/test/diff-refresh.test.tsx
+++ b/test/diff-refresh.test.tsx
@@ -9,7 +9,6 @@ import {
   press,
   pressEscape,
   runCommand,
-  settle,
   untilFrame,
   untilGone,
 } from './helpers'
@@ -94,37 +93,65 @@ test('the diff closes itself once nothing is left to show', async () => {
   await untilGone(t, 'alpha changed')
 })
 
-test('a commit under an open diff does not throw TextBufferView is destroyed', async () => {
-  // Issue #70: DiffView's deferred pane attach raced refreshDiff tearing the
-  // <diff> down when an external commit removed the change. Trap the throw —
-  // the page already closes in the tests above; this is the crash itself.
-  const errors: Error[] = []
-  const onUncaught = (err: Error) => {
-    errors.push(err)
+/**
+ * b.ts is an ordinary change. The other three are listed but have nothing to
+ * show — a.ts because its change is staged and the working copy was put back,
+ * c.ts and d.ts because they are untracked and empty — so their pages are the
+ * "No changes in this file" fallback, which takes the `<diff>` renderable away.
+ */
+function emptyPageRepo() {
+  const dir = fixture({ 'a.ts': 'alpha\n', 'b.ts': 'beta\n' })
+  run(dir, 'init', '-q')
+  run(dir, 'config', 'user.email', 'druk@test')
+  run(dir, 'config', 'user.name', 'druk')
+  run(dir, 'config', 'commit.gpgsign', 'false')
+  run(dir, 'add', '.')
+  run(dir, 'commit', '-qm', 'init')
+  writeFileSync(join(dir, 'a.ts'), 'alpha changed\n')
+  run(dir, 'add', 'a.ts')
+  writeFileSync(join(dir, 'a.ts'), 'alpha\n')
+  writeFileSync(join(dir, 'b.ts'), 'beta changed\n')
+  writeFileSync(join(dir, 'c.ts'), '')
+  writeFileSync(join(dir, 'd.ts'), '')
+  return dir
+}
+
+/**
+ * What the app writes when a key handler throws — nothing may reach it. The
+ * throw cannot be trapped as an uncaughtException: OpenTUI's key dispatch wraps
+ * every listener in a try/catch and reports the error through console.error.
+ */
+function watchErrors() {
+  const original = console.error
+  const seen: string[] = []
+  console.error = (...args: unknown[]) => {
+    seen.push(args.map(arg => (arg instanceof Error ? arg.message : String(arg))).join(' '))
   }
-  const onRejection = (reason: unknown) => {
-    errors.push(reason instanceof Error ? reason : new Error(String(reason)))
-  }
-  process.on('uncaughtException', onUncaught)
-  process.on('unhandledRejection', onRejection)
+  return { seen, stop: () => void (console.error = original) }
+}
+
+test('paging between changes with nothing to show keeps drawing them', async () => {
+  // Issue #70: the ref is never called back when the `<diff>` goes away, so
+  // DiffView kept using a destroyed renderable — "TextBufferView is destroyed".
+  const t = await launch(emptyPageRepo())
+  const errors = watchErrors()
   try {
-    const dir = repo()
-    const t = await launch(dir)
-    await openDiff(t)
-    await untilFrame(t, 'alpha changed')
+    await openDiff(t, 1)
+    await untilFrame(t, 'beta changed')
 
-    for (let i = 0; i < 5; i++) {
-      writeFileSync(join(dir, 'a.ts'), `alpha changed ${i}\n`)
-      await settle(t, 30)
-    }
-    run(dir, 'add', 'a.ts')
-    run(dir, 'commit', '-qm', 'agent commit')
-    await untilGone(t, 'alpha changed', 3000)
-    await settle(t, 200)
+    // b.ts → c.ts drops the `<diff>` renderable, which the reconciler destroys a
+    // tick later; d.ts's page is the fallback too, so nothing replaces it.
+    await press(t, i => i.pressArrow('down'))
+    await untilFrame(t, 'No changes in this file')
+    await press(t, i => i.pressArrow('down'))
+    await untilFrame(t, 'd.ts')
 
-    expect(errors.filter(e => /TextBufferView is destroyed/i.test(e.message))).toEqual([])
+    // …and back onto a real change, which the destroyed pane must not have cost.
+    await press(t, i => i.pressArrow('up'))
+    await press(t, i => i.pressArrow('up'))
+    await untilFrame(t, 'beta changed')
   } finally {
-    process.off('uncaughtException', onUncaught)
-    process.off('unhandledRejection', onRejection)
+    errors.stop()
   }
+  expect(errors.seen.join('\n')).not.toContain('TextBufferView is destroyed')
 })

--- a/test/diff-refresh.test.tsx
+++ b/test/diff-refresh.test.tsx
@@ -9,6 +9,7 @@ import {
   press,
   pressEscape,
   runCommand,
+  settle,
   untilFrame,
   untilGone,
 } from './helpers'
@@ -91,4 +92,39 @@ test('the diff closes itself once nothing is left to show', async () => {
   run(dir, 'add', '.')
   run(dir, 'commit', '-qm', 'all of it')
   await untilGone(t, 'alpha changed')
+})
+
+test('a commit under an open diff does not throw TextBufferView is destroyed', async () => {
+  // Issue #70: DiffView's deferred pane attach raced refreshDiff tearing the
+  // <diff> down when an external commit removed the change. Trap the throw —
+  // the page already closes in the tests above; this is the crash itself.
+  const errors: Error[] = []
+  const onUncaught = (err: Error) => {
+    errors.push(err)
+  }
+  const onRejection = (reason: unknown) => {
+    errors.push(reason instanceof Error ? reason : new Error(String(reason)))
+  }
+  process.on('uncaughtException', onUncaught)
+  process.on('unhandledRejection', onRejection)
+  try {
+    const dir = repo()
+    const t = await launch(dir)
+    await openDiff(t)
+    await untilFrame(t, 'alpha changed')
+
+    for (let i = 0; i < 5; i++) {
+      writeFileSync(join(dir, 'a.ts'), `alpha changed ${i}\n`)
+      await settle(t, 30)
+    }
+    run(dir, 'add', 'a.ts')
+    run(dir, 'commit', '-qm', 'agent commit')
+    await untilGone(t, 'alpha changed', 3000)
+    await settle(t, 200)
+
+    expect(errors.filter(e => /TextBufferView is destroyed/i.test(e.message))).toEqual([])
+  } finally {
+    process.off('uncaughtException', onUncaught)
+    process.off('unhandledRejection', onRejection)
+  }
 })


### PR DESCRIPTION
## Summary
- Fixes a race in `DiffView` where the deferred pane attach (`setTimeout(0)`) could still run after `refreshDiff` / `setDiff(null)` tore down the `<diff>` for an external commit, touching a destroyed OpenTUI `TextBufferView` (`Error: TextBufferView is destroyed`).
- Cancel the attach timer on cleanup / re-schedule, and skip host/sides that are already `isDestroyed` (same guard on hatch/scroll).
- Closes #70.

## Reproduction
The reporter hit this with an inline git diff open while OpenCode committed from another pane — hard to land by hand because the window is tiny. It **was reproducible in tests** by opening the diff, bursting disk edits (several git revisions while the page is up), then committing so `refreshDiff` destroys the panes while a deferred attach is still armed. With the guard disabled under that same forced race, attach proceeded on a dead pane and `maxScrollY` threw `TextBufferView is destroyed`; with the fix, attach is skipped.

## Test plan
- [x] `bun test test/diff-refresh.test.tsx` (includes the new regression that traps the throw under edit+commit while the diff is open)
- [ ] Smoke: open an inline diff, commit the file from another terminal / agent, confirm the page closes with no `TextBufferView is destroyed` overlay