### PR TITLE
fix(review): survive another writer editing review.json while druk is open

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,14 @@ makes that button the way back, as Esc and Shift+Tab are — for reading
 code with the remarks beside it: `Ctrl+Opt+A` drops a note on the line or selection under
 the cursor (issue / suggestion / question / note, each spelled out in the palette as
 well as behind the chooser), the notes show as `◆` in the gutter and after the line
-(`reviewInline`) and outlive the session in `review.json` beside the config; the panel's
+(`reviewInline`) and outlive the session in `review.json` beside the config — a file druk
+does not own alone: an agent editing it while druk is open is the intended flow, so
+another writer's notes appear live (the config directory is watched; a rename-replaced
+file would strand a watcher on the file itself), druk's saves merge with what the file
+holds rather than clobbering it (an id both sides hold is the file's to win — druk never
+changes a note after creating it), land by temp-and-rename so a reader never catches
+half a file, and set an unreadable file aside as `review.json.corrupt-<ts>` rather than
+rewriting it from nothing; the panel's
 cursor pages the editor the way the source-control panel's pages the diff — the remark's
 file goes up in a preview tab at its line, the keyboard staying in the panel, and the
 remark itself opens as a card under that line, GitHub's arrangement — drawn in a gap of

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -11,6 +11,7 @@ import { watchGitRefs, watchTree } from '../core/fs'
 import { isImagePath } from '../core/image'
 import { isMarkdownPath } from '../core/markdown'
 import { isPdfPath } from '../core/pdf'
+import { watchNotes } from '../core/review'
 import { checkForUpdate, currentVersion } from '../core/update'
 import { extensionProblems } from '../extensions'
 import { languageLabel } from '../languages'
@@ -504,6 +505,11 @@ export function App(props: {
       })
     }),
   )
+
+  // Review notes written by another process — an agent editing review.json is
+  // the notes' documented interop — appear the way git made in another
+  // terminal does: without a restart.
+  onMount(() => onCleanup(watchNotes(review.reloadNotes)))
 
   // The watcher has no follow-up message of its own, so unlike the git callers it
   // reports the clash itself — and clears it again once the files agree, since

--- a/src/app/review.ts
+++ b/src/app/review.ts
@@ -16,7 +16,7 @@ import { createMemo, createSignal } from 'solid-js'
 import { fetchComments, findPullRequest, forgeFor } from '../core/forge'
 import type { ForgeComment, PullRequest } from '../core/forge'
 import { remoteUrl } from '../core/git'
-import { loadNotes, NOTE_LABELS, saveNotes } from '../core/review'
+import { loadNotes, NOTE_LABELS, readNotes, saveNotes } from '../core/review'
 import type { NoteKind, ReviewNote } from '../core/review'
 import type { Git } from './git'
 import type { Panes } from './panes'
@@ -57,17 +57,63 @@ export function createReview(deps: {
   const { say } = status
   const { config } = settings
 
-  const [notes, setNotes] = createSignal<ReviewNote[]>(loadNotes(rootDir))
+  const initial = loadNotes(rootDir)
+  const [notes, setNotes] = createSignal<ReviewNote[]>(initial)
   const [comments, setComments] = createSignal<AnchoredComment[]>([])
   const [pull, setPull] = createSignal<PullRequest | null>(null)
   const [fetching, setFetching] = createSignal(false)
   const [collapsed, setCollapsed] = createSignal<ReadonlySet<string>>(new Set())
   const [cursor, setCursor] = createSignal(0)
 
+  // What lets a save merge instead of clobber (`seen`), and an adopt tell an
+  // external delete from a stale writer's overwrite: a note this session
+  // created is only surrendered once some external read contained it
+  // (`acknowledged`) — before that, a file without it was written blind.
+  const seen = new Set(initial.map(note => note.id))
+  const created = new Set<string>()
+  const acknowledged = new Set<string>()
+
   /** Notes are the one thing here that outlives the session, so every write persists. */
   const writeNotes = (next: ReviewNote[]) => {
+    for (const note of next) seen.add(note.id)
     setNotes(next)
-    saveNotes(rootDir, next)
+    saveNotes(rootDir, next, { seen })
+  }
+
+  const sameNote = (a: ReviewNote, b: ReviewNote) =>
+    a.id === b.id &&
+    a.path === b.path &&
+    a.line === b.line &&
+    a.endLine === b.endLine &&
+    a.kind === b.kind &&
+    a.body === b.body &&
+    a.at === b.at
+
+  /**
+   * Adopt what the file says — the way git state made in another terminal
+   * shows up without a restart. The value compare is what absorbs the watcher
+   * reporting druk's own renamed-into-place save, and it must run before any
+   * bookkeeping: an equal file has nothing external in it to acknowledge.
+   */
+  const reloadNotes = () => {
+    const fresh = readNotes(rootDir)
+    // Unreadable is another writer caught mid-file: "not now", never "no notes".
+    if (fresh === null) return
+    const held = notes()
+    if (fresh.length === held.length && fresh.every((note, i) => sameNote(note, held[i]!))) return
+    const freshIds = new Set(fresh.map(note => note.id))
+    // A session-created note no external read has ever contained was clobbered
+    // by a writer holding a stale copy, not deleted — it goes back, and back to
+    // disk. One that some read did contain is the file's to delete.
+    const orphaned = held.filter(
+      note => created.has(note.id) && !acknowledged.has(note.id) && !freshIds.has(note.id),
+    )
+    for (const id of freshIds) {
+      seen.add(id)
+      if (created.has(id)) acknowledged.add(id)
+    }
+    if (orphaned.length === 0) return setNotes(fresh)
+    writeNotes([...fresh, ...orphaned])
   }
 
   /** Ids only have to be unique within this list; the clock plus a counter is that. */
@@ -76,6 +122,7 @@ export function createReview(deps: {
 
   const add = (note: Omit<ReviewNote, 'id' | 'at'>) => {
     const full: ReviewNote = { ...note, id: nextId(), at: Date.now() }
+    created.add(full.id)
     writeNotes([...notes(), full])
     const where = `${basename(note.path)}:${note.line + 1}`
     say(`${NOTE_LABELS[note.kind]} noted on ${where} — ${notes().length} in this review`)
@@ -374,6 +421,7 @@ export function createReview(deps: {
     add,
     removeNote,
     clear,
+    reloadNotes,
     fetchPullRequest: () => void fetchPullRequest(),
     autoFetch,
     /** The header's count, which no fold narrows. */

--- a/src/app/review.ts
+++ b/src/app/review.ts
@@ -45,6 +45,9 @@ const GENERAL = 'On the pull request'
 /** One line of a remark, for a row that has one line to draw it in. */
 const oneLine = (text: string) => text.replaceAll(/\s+/g, ' ').trim()
 
+/** How long after creating a note an external write missing it reads as a stale clobber. */
+const RESCUE_WINDOW = 2000
+
 export function createReview(deps: {
   rootDir: string
   status: Status
@@ -66,12 +69,10 @@ export function createReview(deps: {
   const [cursor, setCursor] = createSignal(0)
 
   // What lets a save merge instead of clobber (`seen`), and an adopt tell an
-  // external delete from a stale writer's overwrite: a note this session
-  // created is only surrendered once some external read contained it
-  // (`acknowledged`) — before that, a file without it was written blind.
+  // external delete from a stale writer's overwrite (`created`, against the
+  // note's own age).
   const seen = new Set(initial.map(note => note.id))
   const created = new Set<string>()
-  const acknowledged = new Set<string>()
 
   /** Notes are the one thing here that outlives the session, so every write persists. */
   const writeNotes = (next: ReviewNote[]) => {
@@ -91,9 +92,10 @@ export function createReview(deps: {
 
   /**
    * Adopt what the file says — the way git state made in another terminal
-   * shows up without a restart. The value compare is what absorbs the watcher
-   * reporting druk's own renamed-into-place save, and it must run before any
-   * bookkeeping: an equal file has nothing external in it to acknowledge.
+   * shows up without a restart. The value compare absorbs a watch event that
+   * reports a save of druk's own, which some platforms deliver and some do
+   * not: a rename is announced under whichever of the two names the platform
+   * picks, and the temp one is filtered out by name.
    */
   const reloadNotes = () => {
     const fresh = readNotes(rootDir)
@@ -102,16 +104,17 @@ export function createReview(deps: {
     const held = notes()
     if (fresh.length === held.length && fresh.every((note, i) => sameNote(note, held[i]!))) return
     const freshIds = new Set(fresh.map(note => note.id))
-    // A session-created note no external read has ever contained was clobbered
-    // by a writer holding a stale copy, not deleted — it goes back, and back to
-    // disk. One that some read did contain is the file's to delete.
+    // A note this session created seconds ago, gone from a file druk did not
+    // write, was clobbered by a writer holding a copy read before it existed —
+    // so it goes back, and back to disk. Age is what separates that from a
+    // deliberate delete: druk cannot see whether the other side read the file
+    // before or after the save, and only the racing writer is quick. Past the
+    // window the file is right and the note is the file's to delete.
     const orphaned = held.filter(
-      note => created.has(note.id) && !acknowledged.has(note.id) && !freshIds.has(note.id),
+      note =>
+        created.has(note.id) && !freshIds.has(note.id) && Date.now() - note.at < RESCUE_WINDOW,
     )
-    for (const id of freshIds) {
-      seen.add(id)
-      if (created.has(id)) acknowledged.add(id)
-    }
+    for (const id of freshIds) seen.add(id)
     if (orphaned.length === 0) return setNotes(fresh)
     writeNotes([...fresh, ...orphaned])
   }

--- a/src/core/review.ts
+++ b/src/core/review.ts
@@ -6,9 +6,16 @@
  * kept beside the config rather than in the project, keyed by project path, as
  * `sessions.json` is: a draft remark is personal scratch, and a `.druk/` file
  * would land in somebody's commit the first time they staged everything.
+ *
+ * druk is not the file's only writer: the kinds are documented by what each
+ * means to an agent, and an agent holding up its end edits `review.json` while
+ * druk has it open. Everything below is shaped by that — writes land by
+ * rename, an unreadable file is set aside rather than rewritten from nothing,
+ * and a save merges with what another writer put there instead of clobbering
+ * it.
  */
 import fs from 'node:fs'
-import { dirname, join } from 'node:path'
+import { basename, dirname, join } from 'node:path'
 
 import { CONFIG_FILE } from './config'
 
@@ -70,40 +77,140 @@ function parseNote(raw: unknown): ReviewNote | null {
 
 type NotesFile = Record<string, { notes: unknown; touchedAt?: number }>
 
-function readAll(file = NOTES_FILE): NotesFile {
+/**
+ * The whole file: `{}` for a missing one, `null` for one that exists but does
+ * not read as an object. The two must stay apart — treating an unreadable
+ * file as empty means rewriting it from nothing, which wipes every project's
+ * notes the moment a torn or foreign write is caught mid-read.
+ */
+function readAll(file: string): NotesFile | null {
+  let raw: string
   try {
-    const raw: unknown = JSON.parse(fs.readFileSync(file, 'utf8'))
-    return typeof raw === 'object' && raw !== null ? (raw as NotesFile) : {}
+    raw = fs.readFileSync(file, 'utf8')
   } catch {
     return {}
   }
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    return typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
+      ? (parsed as NotesFile)
+      : null
+  } catch {
+    return null
+  }
+}
+
+const notesOf = (entry: NotesFile[string] | undefined): ReviewNote[] =>
+  entry && Array.isArray(entry.notes)
+    ? entry.notes.map(parseNote).filter((note): note is ReviewNote => note !== null)
+    : []
+
+/**
+ * This project's notes, or `null` for a file that exists but cannot be read.
+ * The caller decides what that means: "no notes" at startup, "not now" on a
+ * reload that may have caught another writer mid-file.
+ */
+export function readNotes(rootDir: string, file = NOTES_FILE): ReviewNote[] | null {
+  const all = readAll(file)
+  return all === null ? null : notesOf(all[rootDir])
 }
 
 /** This project's notes. Anything unreadable means "no notes", never an error. */
 export function loadNotes(rootDir: string, file = NOTES_FILE): ReviewNote[] {
-  const entry = readAll(file)[rootDir]
-  if (!entry || !Array.isArray(entry.notes)) return []
-  return entry.notes.map(parseNote).filter((note): note is ReviewNote => note !== null)
+  return readNotes(rootDir, file) ?? []
 }
 
-export function saveNotes(
-  rootDir: string,
-  notes: ReviewNote[],
-  now = Date.now(),
-  file = NOTES_FILE,
-): void {
-  try {
-    const all = readAll(file)
-    if (notes.length === 0) delete all[rootDir]
-    else all[rootDir] = { notes, touchedAt: now }
+export interface SaveOptions {
+  /**
+   * Ids this session has accounted for — loaded at startup, created here, or
+   * adopted from a watch event. A file-side note outside the set was written
+   * by another process while this one held its stale copy, so it is kept; one
+   * inside the set but absent from `notes` was removed here, and stays gone.
+   * Every id in `notes` must already be in the set, or a save can double it.
+   */
+  seen?: ReadonlySet<string>
+  now?: number
+  file?: string
+}
 
+export function saveNotes(rootDir: string, notes: ReviewNote[], options: SaveOptions = {}): void {
+  const { seen, now = Date.now(), file = NOTES_FILE } = options
+  try {
+    let all = readAll(file)
+    if (all === null) {
+      // Somebody's data either way — set it aside where a human can recover
+      // it, and only then start fresh.
+      try {
+        fs.renameSync(file, `${file}.corrupt-${now}`)
+      } catch {
+        // the rename failing leaves only writing over it
+      }
+      all = {}
+    }
+
+    const held = notesOf(all[rootDir])
+    const byId = new Map(held.map(note => [note.id, note]))
+    // The file's copy wins for an id both sides hold: druk never changes a
+    // note after creating it, so any difference is another writer's newer
+    // intent. The entry goes only when the *merged* list is empty — druk's
+    // list alone being empty may just be a clear racing an external add.
+    const merged = seen
+      ? [
+          ...notes.map(note => byId.get(note.id) ?? note),
+          ...held.filter(note => !seen.has(note.id)),
+        ]
+      : notes
+    if (merged.length === 0) delete all[rootDir]
+    else all[rootDir] = { notes: merged, touchedAt: now }
+
+    // A writer that omits touchedAt gets this save's clock, not epoch zero —
+    // sorting it to the bottom would make it the trim's first casualty.
     const trimmed = Object.entries(all)
-      .toSorted((a, b) => (b[1].touchedAt ?? 0) - (a[1].touchedAt ?? 0))
+      .toSorted((a, b) => (b[1].touchedAt ?? now) - (a[1].touchedAt ?? now))
       .slice(0, MAX_PROJECTS)
 
     fs.mkdirSync(dirname(file), { recursive: true })
-    fs.writeFileSync(file, `${JSON.stringify(Object.fromEntries(trimmed), null, 2)}\n`)
+    // Written beside and renamed into place, so a reader in another process
+    // can never catch half a file.
+    const tmp = `${file}.${process.pid}.tmp`
+    fs.writeFileSync(tmp, `${JSON.stringify(Object.fromEntries(trimmed), null, 2)}\n`)
+    try {
+      fs.renameSync(tmp, file)
+    } catch (error) {
+      try {
+        fs.unlinkSync(tmp)
+      } catch {
+        // the temp file outliving the failure is noise, not damage
+      }
+      throw error
+    }
   } catch {
     // best-effort — losing a draft note is never worth interrupting the editor
+  }
+}
+
+/**
+ * Report writes to the notes file. The watch is on the directory, not the
+ * file: saves land by rename, which strands a watcher bound to the replaced
+ * file's inode, and only the directory sees the file's first-ever creation.
+ * Returns a stop function; best-effort, as every watcher here is.
+ */
+export function watchNotes(onChange: () => void, file = NOTES_FILE): () => void {
+  let timer: ReturnType<typeof setTimeout> | null = null
+  let watcher: fs.FSWatcher | null = null
+  const name = basename(file)
+  try {
+    fs.mkdirSync(dirname(file), { recursive: true })
+    watcher = fs.watch(dirname(file), (_event, filename) => {
+      if (filename && filename.toString() !== name) return
+      if (timer) clearTimeout(timer)
+      timer = setTimeout(onChange, 80) // coalesce bursts, as watchTree does
+    })
+  } catch {
+    // best-effort: the notes just go unwatched
+  }
+  return () => {
+    if (timer) clearTimeout(timer)
+    watcher?.close()
   }
 }

--- a/test/review-store.test.ts
+++ b/test/review-store.test.ts
@@ -1,0 +1,114 @@
+import { expect, test } from 'bun:test'
+import { mkdtempSync, readdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { loadNotes, readNotes, saveNotes } from '../src/core/review'
+import type { ReviewNote } from '../src/core/review'
+
+const notesFile = () => join(mkdtempSync(join(tmpdir(), 'druk-review-store-')), 'review.json')
+
+const note = (id: string, over: Partial<ReviewNote> = {}): ReviewNote => ({
+  id,
+  path: '/p/src/a.ts',
+  line: 1,
+  endLine: 1,
+  kind: 'issue',
+  body: id,
+  at: 1,
+  ...over,
+})
+
+test('a save keeps the note another writer added meanwhile', () => {
+  const file = notesFile()
+  // The agent wrote first; this session has never seen "theirs".
+  saveNotes('/p', [note('theirs')], { file })
+  saveNotes('/p', [note('mine')], { seen: new Set(['mine']), file })
+  expect(loadNotes('/p', file).map(held => held.id).toSorted()).toEqual(['mine', 'theirs'])
+})
+
+test('a note removed this session stays removed', () => {
+  const file = notesFile()
+  saveNotes('/p', [note('a'), note('b')], { file })
+  // Both were seen; "a" is gone from the list because this session removed it.
+  saveNotes('/p', [note('b')], { seen: new Set(['a', 'b']), file })
+  expect(loadNotes('/p', file).map(held => held.id)).toEqual(['b'])
+})
+
+test("the file's copy wins for an id both sides hold", () => {
+  const file = notesFile()
+  saveNotes('/p', [note('a', { body: 'rewritten elsewhere', line: 9, endLine: 9 })], { file })
+  // This session still holds the original — its copy is the stale one.
+  saveNotes('/p', [note('a')], { seen: new Set(['a']), file })
+  const held = loadNotes('/p', file)
+  expect(held).toHaveLength(1)
+  expect(held[0]!.body).toBe('rewritten elsewhere')
+  expect(held[0]!.line).toBe(9)
+})
+
+test('a clear does not delete the note another writer just added', () => {
+  const file = notesFile()
+  saveNotes('/p', [note('theirs')], { file })
+  saveNotes('/p', [], { seen: new Set(['mine']), file })
+  expect(loadNotes('/p', file).map(held => held.id)).toEqual(['theirs'])
+  // With nothing external left either, the entry itself goes.
+  saveNotes('/p', [], { seen: new Set(['mine', 'theirs']), file })
+  expect(readFileSync(file, 'utf8')).not.toContain('/p')
+})
+
+test("another project's entry passes through a save untouched", () => {
+  const file = notesFile()
+  saveNotes('/other', [note('x', { path: '/other/b.ts' })], { file })
+  saveNotes('/p', [note('mine')], { seen: new Set(['mine']), file })
+  expect(loadNotes('/other', file)).toEqual([note('x', { path: '/other/b.ts' })])
+})
+
+test('an unreadable file is set aside, never rewritten from nothing', () => {
+  const file = notesFile()
+  writeFileSync(file, '{ torn mid-write')
+  saveNotes('/p', [note('mine')], { seen: new Set(['mine']), now: 7, file })
+  const dir = join(file, '..')
+  const aside = readdirSync(dir).find(name => name.startsWith('review.json.corrupt-'))
+  expect(aside).toBeDefined()
+  expect(readFileSync(join(dir, aside!), 'utf8')).toBe('{ torn mid-write')
+  expect(loadNotes('/p', file)).toEqual([note('mine')])
+})
+
+test('reading tells "unreadable" apart from "missing"', () => {
+  const file = notesFile()
+  expect(readNotes('/p', file)).toEqual([])
+  writeFileSync(file, 'not json')
+  expect(readNotes('/p', file)).toBeNull()
+  expect(loadNotes('/p', file)).toEqual([])
+})
+
+test('no temp file outlives a save', () => {
+  const file = notesFile()
+  saveNotes('/p', [note('mine')], { seen: new Set(['mine']), file })
+  expect(readdirSync(join(file, '..'))).toEqual(['review.json'])
+})
+
+test('the trim drops the least recently touched project, not the most', () => {
+  const file = notesFile()
+  for (let i = 1; i <= 21; i++) {
+    saveNotes(`/p${i}`, [note(`n${i}`, { path: `/p${i}/a.ts` })], { now: i, file })
+  }
+  expect(loadNotes('/p1', file)).toEqual([])
+  expect(loadNotes('/p2', file)).toHaveLength(1)
+  expect(loadNotes('/p21', file)).toHaveLength(1)
+})
+
+test('an entry saved without touchedAt is fresh, not the first casualty', () => {
+  const file = notesFile()
+  for (let i = 1; i <= 20; i++) {
+    saveNotes(`/p${i}`, [note(`n${i}`, { path: `/p${i}/a.ts` })], { now: i, file })
+  }
+  // An agent wrote an entry with no touchedAt at all.
+  const all = JSON.parse(readFileSync(file, 'utf8')) as Record<string, unknown>
+  all['/agent'] = { notes: [note('theirs', { path: '/agent/a.ts' })] }
+  writeFileSync(file, JSON.stringify(all))
+  saveNotes('/p1', [note('n1', { path: '/p1/a.ts' })], { seen: new Set(['n1']), now: 22, file })
+  expect(loadNotes('/agent', file)).toHaveLength(1)
+  // The eldest stamped entry paid for the trim instead.
+  expect(loadNotes('/p2', file)).toEqual([])
+})

--- a/test/review-store.test.ts
+++ b/test/review-store.test.ts
@@ -24,7 +24,11 @@ test('a save keeps the note another writer added meanwhile', () => {
   // The agent wrote first; this session has never seen "theirs".
   saveNotes('/p', [note('theirs')], { file })
   saveNotes('/p', [note('mine')], { seen: new Set(['mine']), file })
-  expect(loadNotes('/p', file).map(held => held.id).toSorted()).toEqual(['mine', 'theirs'])
+  expect(
+    loadNotes('/p', file)
+      .map(held => held.id)
+      .toSorted(),
+  ).toEqual(['mine', 'theirs'])
 })
 
 test('a note removed this session stays removed', () => {

--- a/test/review.test.tsx
+++ b/test/review.test.tsx
@@ -471,6 +471,27 @@ test('a stale overwrite gives back the note it never saw', async () => {
   await until(t, () => readFileSync(NOTES_PATH, 'utf8').includes('written here'))
 })
 
+test('an agent may delete a note druk wrote, once it is not a race', async () => {
+  const dir = fixture(PROJECT)
+  const t = await launch(dir, {}, { width: 100, height: 24 })
+  await openFile(t, 'a.ts')
+  await noteLine(t, 'issue', 'fix this')
+  await runCommand(t, 'Review panel')
+  await untilFrame(t, 'fix this')
+  expect(readFileSync(NOTES_PATH, 'utf8')).toContain('fix this')
+
+  // Long enough that the note is no longer young enough to rescue — the whole
+  // point being that past that age an absence is a delete and not a clobber,
+  // which is the flow the notes exist for: the agent fixes and strikes off.
+  await settle(t, 2300)
+  writeFileSync(NOTES_PATH, JSON.stringify({ [dir]: { notes: [], touchedAt: 2 } }))
+
+  await untilGone(t, 'fix this')
+  // And it stays gone: no save puts it back behind the panel.
+  await settle(t, 200)
+  expect(readFileSync(NOTES_PATH, 'utf8')).not.toContain('fix this')
+})
+
 test('an unreadable notes file changes nothing on screen', async () => {
   const dir = fixture(PROJECT)
   writeFileSync(

--- a/test/review.test.tsx
+++ b/test/review.test.tsx
@@ -17,6 +17,7 @@ import {
   pressTimes,
   runCommand,
   settle,
+  until,
   untilFrame,
   untilGone,
 } from './helpers'
@@ -418,4 +419,72 @@ test('a note taken on a selection carries the whole span', async () => {
   await runCommand(t, 'Note this line as issue')
   expect(t.captureCharFrame()).toContain('a.ts:1-2')
   await pressEscape(t)
+})
+
+// ── Another writer, while druk is open ──────────────────────────────────────
+
+const NOTES_PATH = join(process.env.XDG_CONFIG_HOME!, 'druk', 'review.json')
+
+const theirNote = (dir: string, id: string, body: string) => ({
+  id,
+  path: join(dir, 'a.ts'),
+  line: 0,
+  endLine: 0,
+  kind: 'note',
+  body,
+  at: 1,
+})
+
+test('a note written by another process appears, and its delete empties', async () => {
+  const dir = fixture(PROJECT)
+  const t = await launch(dir, {}, { width: 100, height: 24 })
+  await runCommand(t, 'Review panel')
+  await untilFrame(t, 'No notes yet')
+
+  writeFileSync(
+    NOTES_PATH,
+    JSON.stringify({ [dir]: { notes: [theirNote(dir, 'x1', 'left by an agent')], touchedAt: 1 } }),
+  )
+  await untilFrame(t, 'left by an agent')
+
+  writeFileSync(NOTES_PATH, '{}\n')
+  await untilGone(t, 'left by an agent')
+})
+
+test('a stale overwrite gives back the note it never saw', async () => {
+  const dir = fixture(PROJECT)
+  const t = await launch(dir, {}, { width: 100, height: 24 })
+  await openFile(t, 'a.ts')
+  await noteLine(t, 'issue', 'written here')
+  await untilFrame(t, 'written here')
+
+  // An agent that read the file before the note existed writes its stale copy
+  // back — with its own note, without druk's.
+  writeFileSync(
+    NOTES_PATH,
+    JSON.stringify({ [dir]: { notes: [theirNote(dir, 'x2', 'left by an agent')], touchedAt: 1 } }),
+  )
+  await runCommand(t, 'Review panel')
+  await untilFrame(t, 'left by an agent')
+  await untilFrame(t, 'written here')
+  // And the rescue reached the disk, not just the panel.
+  await until(t, () => readFileSync(NOTES_PATH, 'utf8').includes('written here'))
+})
+
+test('an unreadable notes file changes nothing on screen', async () => {
+  const dir = fixture(PROJECT)
+  writeFileSync(
+    NOTES_PATH,
+    JSON.stringify({
+      [dir]: { notes: [theirNote(dir, 'x3', 'held before the tear')], touchedAt: 1 },
+    }),
+  )
+  const t = await launch(dir, {}, { width: 100, height: 24 })
+  await runCommand(t, 'Review panel')
+  await untilFrame(t, 'held before the tear')
+
+  writeFileSync(NOTES_PATH, '{ torn mid-write')
+  // The assertion is that nothing happened, so the fixed wait is the right tool.
+  await settle(t, 300)
+  expect(t.captureCharFrame()).toContain('held before the tear')
 })

--- a/test/review.test.tsx
+++ b/test/review.test.tsx
@@ -245,11 +245,11 @@ test('notes survive a restart, and clearing forgets the project', () => {
     body: 'wrong',
     at: 1,
   }
-  saveNotes('/p', [note], 1, file)
+  saveNotes('/p', [note], { now: 1, file })
   expect(loadNotes('/p', file)).toEqual([note])
   // Another project's notes are not this one's.
   expect(loadNotes('/other', file)).toEqual([])
-  saveNotes('/p', [], 2, file)
+  saveNotes('/p', [], { now: 2, file })
   expect(loadNotes('/p', file)).toEqual([])
 })
 


### PR DESCRIPTION
#73 reports notes corrupting when an AI agent edits them while druk is open — "if an AI agent edits the notes while Druk is open, they can become corrupted." Confirmed, and it was a little worse than reported: druk read `review.json` once at startup and never again, so any external change was clobbered by the next save's stale copy; the write was a plain `writeFileSync`, so another reader could catch half a file; and the save path swallowed a parse failure into `{}` — druk catching a torn or foreign write on its own read would rewrite the file from nothing, wiping every project's notes, not just the open one's.

The notes are documented by what each kind means to an agent, so an agent editing the file mid-session is the intended flow, not an abuse. This makes druk hold up its end:

- **Saves merge instead of clobber.** A save re-reads the file and keeps any note this session has never seen — an external add racing it. For an id both sides hold, the file's copy wins: druk never changes a note after creating it, so a difference is always the other writer's newer intent. The project entry is only dropped when the *merged* list is empty, so a clear cannot take an unseen external note with it.
- **Writes land by rename.** Temp file beside, renamed into place; a reader in another process can no longer catch a torn file.
- **An unreadable file is set aside, never zeroed.** The read now tells "missing" from "exists but does not parse"; the second is quarantined as `review.json.corrupt-<ts>` before a fresh write, so nothing is silently discarded.
- **External edits appear live.** The config directory is watched — watching the file itself would strand the watcher on the first rename-replace — and the open session adopts what the file says, the way git work done in another terminal already shows up. A torn read on that path means "not now", never "no notes". And a note added in druk that a slow read-modify-write writer clobbered (the agent read before the note existed) is put back and re-saved; a delete of a note the other side demonstrably saw still wins.

Chosen rather than missed: this is last-writer-wins on a shared scratch file, not conflict resolution — a delete made by an agent inside the watch debounce can be resurrected by a druk save racing it. Tombstones or per-note clocks would close that and are not worth their weight for draft remarks.

Tests: a store suite for the merge, the quarantine, the rename write and the trim (including an entry another writer saved without `touchedAt`, which used to be the trim's first casualty), and three app-level tests driving the real watcher — an external add appears without a restart, an external delete empties the panel, and a stale overwrite gives back the note it never saw. `bun run check` is green, and AGENTS.md carries the new contract.
