### PR TITLE
feat(release): deb and rpm packages on every release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,24 @@ jobs:
       # at it, and a release missing them sends every `brew install` back to a source
       # build — which is what fails on a machine whose Xcode trails its macOS (issue #40).
       - run: bun run formula
+      # nfpm turns the linux binaries into .deb/.rpm files in dist/release/, which
+      # the upload below carries like everything else there. Pinned by version and
+      # by the tarball's SHA-256 as a literal here — a checksum fetched from the
+      # same origin as the artifact would verify nothing. The fetch is a hard
+      # dependency of the release on purpose: `druk update` points system installs
+      # at these assets, so a release shipped without them is the same
+      # published-pointer-to-nothing failure the npm and upload steps refuse to
+      # allow each other. Re-running a shipped version stays safe, and a yanked
+      # tarball is a one-line pin bump.
+      - name: Package for deb and rpm
+        run: |
+          curl -fsSL -o nfpm.tar.gz \
+            https://github.com/goreleaser/nfpm/releases/download/v2.47.0/nfpm_2.47.0_Linux_x86_64.tar.gz
+          echo "0660ca602b2d2d2ae4781a06c692b3eeb9d437ffea05b831d76e41f4a3188783  nfpm.tar.gz" | sha256sum -c -
+          tar -xzf nfpm.tar.gz nfpm
+          sudo mv nfpm /usr/local/bin/nfpm
+          rm nfpm.tar.gz
+          bun run packages
       # git, not `gh release create --target`: GITHUB_TOKEN may create a release for a
       # tag that already exists, but creating one that has to create the tag too comes
       # back `403 Resource not accessible by integration`. Pushing the tag over the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -400,6 +400,7 @@ bun run build            # compile a binary for this machine into dist/<target>/
 bun run build linux-x64  # …or for a named target, if its native package is installed
 bun run release          # package dist/ for npm + release archives (--publish to ship)
 bun run formula          # Homebrew formula for those archives, into dist/release/druk.rb
+bun run packages         # .deb/.rpm from the linux binaries, into dist/release/ (needs nfpm)
 bun run extensions          # regenerate extensions/index.json — the market's catalog
 bun run test             # unit + UI, one file per process, sequential (~4 min)
 bun test test/foo.tsx    # a single file, where the flag buys nothing
@@ -473,6 +474,14 @@ step may be made conditional on its own, because druk 1.0.0 reached npm from a r
 release upload was skipped, and the published shim spent its life fetching a release that
 did not exist. Re-running a shipped version is safe — `release.ts` skips a version already
 on the registry and the upload clobbers its assets.
+
+**The deb/rpm packages are a hard step of the release, not a tap-style extra.** The
+publish job fetches nfpm pinned by version and by a SHA-256 written into the workflow
+(a checksum fetched beside the artifact would verify nothing) and runs
+`bun run packages` after the formula. It fails the release when it fails, on purpose:
+`druk update` points system installs at these assets, so a release without them is the
+published-pointer-to-nothing failure the npm and upload steps already refuse to allow
+each other — the tap's graceful skip is for a result nothing reads.
 
 **Homebrew needs the one credential the rest of the release does without.** The workflow
 runs `bun run formula` after packaging, so `druk.rb` — checksummed against the archives

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ bun add -g druk
 
 On Debian or Ubuntu, take the `.deb` from the
 [releases page](https://github.com/letstri/druk/releases) (`sudo dpkg -i druk_*.deb`);
-on Fedora or openSUSE the `.rpm` (`sudo rpm -i druk-*.rpm`).
+on Fedora or openSUSE the `.rpm` (`sudo rpm -U druk-*.rpm`).
 
 macOS (arm64, x64), Linux (arm64, x64) and Windows (x64). Binaries are also on the
 releases page.

--- a/README.md
+++ b/README.md
@@ -27,8 +27,12 @@ npm install -g druk
 bun add -g druk
 ```
 
+On Debian or Ubuntu, take the `.deb` from the
+[releases page](https://github.com/letstri/druk/releases) (`sudo dpkg -i druk_*.deb`);
+on Fedora or openSUSE the `.rpm` (`sudo rpm -i druk-*.rpm`).
+
 macOS (arm64, x64), Linux (arm64, x64) and Windows (x64). Binaries are also on the
-[releases page](https://github.com/letstri/druk/releases).
+releases page.
 
 To upgrade later, whichever way you installed:
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "build": "bun build.ts",
     "release": "bun scripts/release.ts",
     "formula": "bun scripts/formula.ts",
+    "packages": "bun scripts/packages.ts",
     "extensions": "bun scripts/extensions.ts",
     "check-types": "tsc --noEmit",
     "lint": "oxlint",

--- a/scripts/packages.ts
+++ b/scripts/packages.ts
@@ -1,0 +1,101 @@
+import { existsSync } from 'node:fs'
+import { mkdir, rm, writeFile } from 'node:fs/promises'
+
+/**
+ * Turns the Linux binaries in dist/<target>/ into .deb and .rpm packages in
+ * dist/release/, for the publish job to upload beside the archives.
+ *
+ * nfpm reads one YAML config per invocation; the config is built here rather
+ * than committed, so the pure part runs under `bun run check` and
+ * package.json stays the only place a version lives. nfpm itself is fetched
+ * by the workflow, pinned by version and checksum — this script only ever
+ * finds it on PATH or says it could not.
+ */
+
+export type LinuxTarget = 'linux-x64' | 'linux-arm64'
+export type PackageFormat = 'deb' | 'rpm'
+
+export const LINUX_TARGETS: LinuxTarget[] = ['linux-x64', 'linux-arm64']
+export const FORMATS: PackageFormat[] = ['deb', 'rpm']
+
+/** nfpm takes Go's arch names and translates per packager. */
+const GOARCH: Record<LinuxTarget, string> = {
+  'linux-x64': 'amd64',
+  'linux-arm64': 'arm64',
+}
+
+/** What the file is called in each ecosystem's own vocabulary and shape. */
+const FILE_ARCH: Record<PackageFormat, Record<LinuxTarget, string>> = {
+  deb: { 'linux-x64': 'amd64', 'linux-arm64': 'arm64' },
+  rpm: { 'linux-x64': 'x86_64', 'linux-arm64': 'aarch64' },
+}
+
+export function packageFileName(
+  format: PackageFormat,
+  target: LinuxTarget,
+  version: string,
+): string {
+  const arch = FILE_ARCH[format][target]
+  // rpm's own naming is name-version-release.arch; mirroring deb's underscores
+  // there would read as foreign to every rpm tool and user.
+  return format === 'deb' ? `druk_${version}_${arch}.deb` : `druk-${version}-1.${arch}.rpm`
+}
+
+/** The nfpm config for one target — the same for both formats it packages. */
+export function nfpmConfig(target: LinuxTarget, version: string, distDir = './dist'): string {
+  return [
+    `name: druk`,
+    `arch: ${GOARCH[target]}`,
+    `platform: linux`,
+    `version: ${version}`,
+    `maintainer: Valerii Strilets`,
+    `homepage: https://github.com/letstri/druk`,
+    `license: MIT`,
+    `description: >-`,
+    `  A terminal code editor — file tree, tabs, tree-sitter syntax highlighting`,
+    `  and search; keyboard and mouse driven.`,
+    `contents:`,
+    `  - src: ${distDir}/${target}/druk`,
+    `    dst: /usr/bin/druk`,
+    `    file_info:`,
+    `      mode: 0755`,
+    `  - src: ./LICENSE`,
+    `    dst: /usr/share/doc/druk/LICENSE`,
+    `  - src: ./THIRD_PARTY_NOTICES.md`,
+    `    dst: /usr/share/doc/druk/THIRD_PARTY_NOTICES.md`,
+    `  - src: ./third_party/PDFIUM_LICENSE`,
+    `    dst: /usr/share/doc/druk/PDFIUM_LICENSE`,
+    ``,
+  ].join('\n')
+}
+
+if (import.meta.main) {
+  const distDir = process.env.DRUK_DIST ?? './dist'
+  const { version } = await Bun.file('./package.json').json()
+
+  for (const target of LINUX_TARGETS) {
+    const binary = `${distDir}/${target}/druk`
+    if (!existsSync(binary)) {
+      process.stderr.write(`missing binary: ${binary} — run the ${target} build first\n`)
+      process.exit(1)
+    }
+  }
+  if (!Bun.which('nfpm')) {
+    process.stderr.write('nfpm is not on PATH — the release workflow installs it pinned\n')
+    process.exit(1)
+  }
+
+  const outDir = `${distDir}/release`
+  await mkdir(outDir, { recursive: true })
+  for (const target of LINUX_TARGETS) {
+    const config = `${outDir}/nfpm-${target}.yaml`
+    await writeFile(config, nfpmConfig(target, version, distDir))
+    for (const format of FORMATS) {
+      const out = `${outDir}/${packageFileName(format, target, version)}`
+      await Bun.$`nfpm package -f ${config} -p ${format} -t ${out}`
+      process.stdout.write(`packaged ${out}\n`)
+    }
+    // The config beside the uploads would ride the release's wildcard glob.
+    await rm(config)
+  }
+}

--- a/src/core/upgrade.ts
+++ b/src/core/upgrade.ts
@@ -14,7 +14,7 @@ import { homedir } from 'node:os'
 import { addDependencyCommand } from 'nypm'
 import type { PackageManagerName } from 'nypm'
 
-export type InstallKind = 'brew' | 'script' | 'package'
+export type InstallKind = 'brew' | 'script' | 'system' | 'package'
 
 export interface Install {
   kind: InstallKind
@@ -46,6 +46,13 @@ export function detectInstall(
   if (/[/\\](?:Cellar|homebrew|linuxbrew)[/\\]/.test(paths)) return { kind: 'brew' }
   // Where the curl installer puts it; nothing else owns that directory.
   if (paths.includes(`${home}/.druk`)) return { kind: 'script' }
+  // The compiled binary at the packaged path: our .deb/.rpm put it there, and so
+  // do other system packagings (the AUR's druk-bin) — hence "a system package
+  // manager" and not a package by name. execPath alone: an npm shim at
+  // /usr/bin/druk runs under node, whose execPath this is not. Ahead of the
+  // manager fallbacks, whose npm default would install a second druk beside
+  // the system one — the exact failure this module exists to avoid.
+  if (execPath === '/usr/bin/druk') return { kind: 'system' }
 
   for (const [manager, pattern] of MANAGER_PATHS) {
     if (pattern.test(paths)) return { kind: 'package', manager }
@@ -53,10 +60,16 @@ export function detectInstall(
   return { kind: 'package', manager: fallback }
 }
 
+/** Where the packages live; a system install is pointed here, never run for. */
+export const RELEASES_URL = 'https://github.com/letstri/druk/releases/latest'
+
 /** The shell command that upgrades this install, ready to print and to run. */
 export function upgradeCommand(install: Install): string {
   if (install.kind === 'brew') return 'brew upgrade letstri/tap/druk'
   if (install.kind === 'script') return 'curl -fsSL https://druk.letstri.dev/install | bash'
+  // Not runnable: no repository is hosted, and the manager that installed it is
+  // not ours to invoke. The URL is the honest answer.
+  if (install.kind === 'system') return RELEASES_URL
   return addDependencyCommand(install.manager ?? 'npm', 'druk@latest', { global: true })
 }
 
@@ -64,8 +77,13 @@ export function upgradeCommand(install: Install): string {
 const DESCRIPTION: Record<InstallKind, (install: Install) => string> = {
   brew: () => 'Updating the Homebrew install.',
   script: () => 'Re-running the install script.',
+  system: () => 'Installed by a system package manager.',
   package: install => `Updating the global ${install.manager ?? 'npm'} install.`,
 }
+
+/** The package filenames for this machine, so the pointer names what to take. */
+const packageNames = (arch: string) =>
+  arch === 'arm64' ? 'the arm64 .deb or aarch64 .rpm' : 'the amd64 .deb or x86_64 .rpm'
 
 /**
  * Run the upgrade, with the child's output going straight to the terminal — the
@@ -76,8 +94,27 @@ const DESCRIPTION: Record<InstallKind, (install: Install) => string> = {
  */
 export async function runUpgrade(
   write: (text: string) => void = text => process.stdout.write(text),
+  // Injectable for the tests, which cannot present /usr/bin/druk as their own
+  // execPath; the defaults are the process's, as before.
+  detection: { execPath?: string; scriptPath?: string; home?: string; arch?: string } = {},
 ): Promise<number> {
-  const install = detectInstall(process.execPath, process.argv[1] ?? '', homedir())
+  const install = detectInstall(
+    detection.execPath ?? process.execPath,
+    detection.scriptPath ?? process.argv[1] ?? '',
+    detection.home ?? homedir(),
+  )
+
+  // Nothing safe to run: updating through the manager that installed it is the
+  // user's move, and running a package manager of our own choosing beside it is
+  // the two-copies failure described at the top of this file.
+  if (install.kind === 'system') {
+    write(
+      `${DESCRIPTION.system(install)}\nUpdate it through that manager, or take ` +
+        `${packageNames(detection.arch ?? process.arch)} from:\n${RELEASES_URL}\n`,
+    )
+    return 0
+  }
+
   const command = upgradeCommand(install)
 
   write(`${DESCRIPTION[install.kind](install)}\n$ ${command}\n\n`)

--- a/test/packages.test.ts
+++ b/test/packages.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { nfpmConfig, packageFileName } from '../scripts/packages'
+
+describe('packageFileName', () => {
+  test('deb keeps underscores and Debian arch names', () => {
+    expect(packageFileName('deb', 'linux-x64', '1.16.0')).toBe('druk_1.16.0_amd64.deb')
+    expect(packageFileName('deb', 'linux-arm64', '1.16.0')).toBe('druk_1.16.0_arm64.deb')
+  })
+
+  test('rpm follows name-version-release.arch, its own shape', () => {
+    expect(packageFileName('rpm', 'linux-x64', '1.16.0')).toBe('druk-1.16.0-1.x86_64.rpm')
+    expect(packageFileName('rpm', 'linux-arm64', '1.16.0')).toBe('druk-1.16.0-1.aarch64.rpm')
+  })
+})
+
+describe('nfpmConfig', () => {
+  test('carries the version as package.json spells it, no tag v', () => {
+    expect(nfpmConfig('linux-x64', '1.16.0')).toContain('version: 1.16.0')
+    expect(nfpmConfig('linux-x64', '1.16.0')).not.toContain('version: v')
+  })
+
+  test('maps the target to Go arch names for nfpm to translate', () => {
+    expect(nfpmConfig('linux-x64', '1.0.0')).toContain('arch: amd64')
+    expect(nfpmConfig('linux-arm64', '1.0.0')).toContain('arch: arm64')
+  })
+
+  test('installs the binary executable to /usr/bin with the three doc files', () => {
+    const config = nfpmConfig('linux-x64', '1.0.0')
+    expect(config).toContain('src: ./dist/linux-x64/druk')
+    expect(config).toContain('dst: /usr/bin/druk')
+    expect(config).toContain('mode: 0755')
+    expect(config).toContain('dst: /usr/share/doc/druk/LICENSE')
+    expect(config).toContain('dst: /usr/share/doc/druk/THIRD_PARTY_NOTICES.md')
+    expect(config).toContain('dst: /usr/share/doc/druk/PDFIUM_LICENSE')
+  })
+})
+
+test('a missing binary is named before nfpm is ever needed', () => {
+  const empty = mkdtempSync(join(tmpdir(), 'druk-dist-'))
+  const proc = Bun.spawnSync(['bun', 'scripts/packages.ts'], {
+    cwd: process.cwd(),
+    env: { ...process.env, DRUK_DIST: empty },
+  })
+  expect(proc.exitCode).toBe(1)
+  expect(new TextDecoder().decode(proc.stderr)).toContain(`${empty}/linux-x64/druk`)
+})

--- a/test/upgrade.test.ts
+++ b/test/upgrade.test.ts
@@ -83,3 +83,37 @@ describe('the help', () => {
     expect(HELP).toContain('upgrade druk itself')
   })
 })
+
+describe('a system package install', () => {
+  test('the packaged path is its own kind, ahead of the npm fallback', () => {
+    expect(detect('/usr/bin/druk')).toEqual({ kind: 'system' })
+    // A shim at that path runs under node, whose execPath is not the binary.
+    expect(detect('/usr/bin/node', '/usr/lib/node_modules/druk/bin/druk.js')).toMatchObject({
+      manager: 'npm',
+    })
+  })
+
+  test('its command is the releases page, since nothing is safe to run', () => {
+    expect(upgradeCommand({ kind: 'system' })).toContain('releases/latest')
+  })
+
+  test('update points at this architecture and spawns nothing', async () => {
+    const written: string[] = []
+    const code = await runUpgrade(text => written.push(text), {
+      execPath: '/usr/bin/druk',
+      arch: 'x64',
+    })
+    const out = written.join('')
+    expect(code).toBe(0)
+    expect(out).toContain('system package manager')
+    expect(out).toContain('amd64 .deb or x86_64 .rpm')
+    expect(out).toContain('releases/latest')
+    expect(out).not.toContain('$ ') // no command was printed, none was run
+  })
+
+  test('arm64 names its own pair', async () => {
+    const written: string[] = []
+    await runUpgrade(text => written.push(text), { execPath: '/usr/bin/druk', arch: 'arm64' })
+    expect(written.join('')).toContain('arm64 .deb or aarch64 .rpm')
+  })
+})


### PR DESCRIPTION
The shape proposed in #65: `.deb` and `.rpm` on every release, from the binaries the release already builds.

`scripts/packages.ts` follows `formula.ts`'s seam — version from `package.json`, four packages dropped into `dist/release/` for the existing upload glob — and `build.ts`'s structure, so the config builder is a pure export the tests exercise under `bun run check`. The binary lands at `/usr/bin/druk` with `LICENSE`, `THIRD_PARTY_NOTICES.md` and `PDFIUM_LICENSE` under `/usr/share/doc/druk/` — the same three files every archive carries. deb files use Debian's naming, rpm files rpm's own `name-version-release.arch`.

The workflow fetches nfpm pinned twice over — by version and by a SHA-256 written into the workflow, since a checksum fetched beside the artifact verifies nothing — and the step hard-fails the release deliberately: `druk update` now points system installs at these assets, so a release shipped without them would be the published-pointer-to-nothing failure the npm and upload steps already refuse to allow each other. The tap's graceful skip stays right for the tap, where nothing reads the result.

That `druk update` change closes today's sharp edge: a `/usr/bin/druk` install currently falls through detection to the npm fallback, and `druk update` would install a second druk beside the system one — the exact failure `upgrade.ts`'s header warns about. A `system` kind now says what it detected and names this architecture's package on the releases page, running nothing. Worded as "a system package manager" rather than claiming our own deb/rpm, since the AUR's `druk-bin` puts the binary at the same path.

Tests: filename and config shapes for all four packages (arch mapping, version passthrough, the three doc files, `/usr/bin` mode), the missing-binary refusal before nfpm is ever needed, and the `system` detection with both architectures' guidance — the existing upgrade cases untouched. `bun run check` is green save for `test/cursor-style.test.tsx`, which fails the same 4 of 8 on today's `main` without this branch (macOS) — pre-existing, not touched here.
