### PR TITLE
Update built-ins only with druk, and apply market updates automatically

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -381,7 +381,9 @@ an extension market — `extensions/` **in this repository**, one folder per ext
 raw from `main`, so a merged pull request is installable without a druk release;
 the panel's `AVAILABLE` section installs one after a confirm that names the
 commands it would have druk spawn, an installed extension with a newer version in the
-catalog is reported in the status bar at startup, a file whose language no
+catalog is reported in the status bar at startup (never a preinstalled one, which is
+part of the binary and updates with druk itself — a disk copy of a built-in's id is
+skipped and reported rather than loaded), a file whose language no
 installed extension serves offers the extension that does, and a config naming a theme
 nothing registers is offered its extension back (`extensionUpdates` turns the whole of
 that off, `extensionRegistry` points it at a fork),

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -381,9 +381,10 @@ an extension market — `extensions/` **in this repository**, one folder per ext
 raw from `main`, so a merged pull request is installable without a druk release;
 the panel's `AVAILABLE` section installs one after a confirm that names the
 commands it would have druk spawn, an installed extension with a newer version in the
-catalog is reported in the status bar at startup (never a preinstalled one, which is
-part of the binary and updates with druk itself — a disk copy of a built-in's id is
-skipped and reported rather than loaded), a file whose language no
+catalog is updated automatically by the startup check, the status bar saying so
+(never a preinstalled one, which is part of the binary and updates with druk itself —
+a disk copy of a built-in's id is skipped and reported rather than loaded; the confirm
+is for first installs alone, an update being a question already answered), a file whose language no
 installed extension serves offers the extension that does, and a config naming a theme
 nothing registers is offered its extension back (`extensionUpdates` turns the whole of
 that off, `extensionRegistry` points it at a fork),

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -726,7 +726,10 @@ is just a diff against the empty tree.
 - **Network.** druk makes two kinds of request, both at startup and both
   best-effort (2.5s timeout, failures ignored): one npm registry lookup for a newer
   druk, disabled by `checkUpdates: false`, and the extension market's `index.json`,
-  disabled by `extensionUpdates: false` and cached for six hours in between. Everything
+  disabled by `extensionUpdates: false` and cached for six hours in between. When that
+  catalog names a newer version of an installed market extension, its manifest is
+  fetched and applied in the same pass — an update is not a new install, so it is not
+  asked about. Everything
   after that is a fetch someone asked for — a manifest, because an extension is being
   installed. druk runs no git command that talks to a
   remote, which is also what

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -322,9 +322,11 @@ Five things hold it together:
   means the registry served something other than what was reviewed.
 - **Some of it ships inside the binary.** [`src/extensions/builtin.ts`](src/extensions/builtin.ts)
   imports a handful of the same manifests as JSON, so a first run highlights the
-  languages most projects open with no network at all. A built-in is an ordinary
-  extension otherwise — listed, disableable, and replaced outright by a copy of the
-  same id on disk, which is how the market updates one. The static imports are
+  languages most projects open with no network at all. A built-in is listed and
+  disableable like any other extension, but it is part of the binary and updates
+  with druk itself: the market never offers it an update, and a disk copy of the
+  same id is skipped and reported rather than loaded — a stale copy would otherwise
+  pin the extension through every druk update. The static imports are
   load-bearing: a computed path resolves to nothing in the compiled binary, so the
   preinstalled set is spelled out rather than globbed.
 - **The catalog is cached and best-effort.** `$XDG_CACHE_HOME/druk/market.json`,

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -165,8 +165,10 @@ update and `1.0.0` re-published is not.
 A few of these ship inside the binary, so a fresh druk highlights code with no
 network: typescript, json, markdown, html, css, yaml and toml. The list is
 `src/extensions/builtin.ts`, and a preinstalled extension may carry no assets — it is
-parsed without a folder, so a relative path would resolve to nothing. Installing
-the market's copy of one replaces the built-in, which is how it gets an update.
+parsed without a folder, so a relative path would resolve to nothing. A preinstalled
+extension updates with druk itself: the market never offers it an update, and a copy
+of its id in an extensions folder is skipped and reported rather than loaded. Bumping
+one's `version` therefore only reaches users through a druk release.
 
 ## Testing yours before it is merged
 

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -158,7 +158,9 @@ up under the plain name too, so `github` covers `.github`, `_github` and
 
 To change an extension, edit its manifest and **bump `version`** — that is the only
 thing that makes installed copies notice. druk compares semver, so `1.0.1` is an
-update and `1.0.0` re-published is not.
+update and `1.0.0` re-published is not. An installed copy applies the update by
+itself the next time its startup check sees the new catalog — nobody is asked, so
+a bumped version reaches users on their next launch.
 
 ## Preinstalled extensions
 

--- a/src/app/market.ts
+++ b/src/app/market.ts
@@ -74,8 +74,12 @@ export function createMarket(deps: {
   const entry = (id: string): MarketEntry | undefined =>
     catalog().find(extension => extension.id === id)
 
+  // Market copies only: a built-in is part of the binary and updates with druk
+  // itself, so the market must never offer it one.
   const installedVersions = () =>
-    extensions().map(extension => ({ id: extension.id, version: extension.version }))
+    extensions()
+      .filter(extension => !extension.builtin)
+      .map(extension => ({ id: extension.id, version: extension.version }))
 
   /** Installed extensions the market has a newer version of. */
   const updates = createMemo(() => updatesFor(installedVersions(), catalog(), isNewer))

--- a/src/app/market.ts
+++ b/src/app/market.ts
@@ -2,10 +2,12 @@
  * The extension market as the editor sees it: what is on offer, what is out of
  * date, and what the open file would want installed.
  *
- * Every path into an install goes through the same two steps — fetch and
+ * Every path into a first install goes through the same two steps — fetch and
  * validate the manifest (`core/market.ts`), then ask. The prompt is raised only
  * once the manifest is in hand, so what it names is the file that will actually
- * be written rather than a claim the catalog made about it.
+ * be written rather than a claim the catalog made about it. An *update* of an
+ * installed extension is applied without asking: the question was answered when
+ * it was installed, and an update kept behind a prompt is an update nobody runs.
  *
  * Nothing here is load-bearing: the catalog is fetched best-effort, and every
  * failure leaves the editor exactly as it was with at most a status line.
@@ -119,7 +121,6 @@ export function createMarket(deps: {
   const offer = async (id: string, why: string, quiet = false): Promise<void> => {
     const found = entry(id)
     if (!found) return void (quiet || status.say(`No extension "${id}" in the market`, 'warn'))
-    const installed = extensions().find(extension => extension.id === id)
     const result = await fetchExtension(id, { registry: registry(), fetcher })
     if (!result.ok) return void (quiet || status.say(`Extension ${id}: ${result.error}`, 'error'))
     // An offer druk raised itself must never replace a question the user is
@@ -136,8 +137,50 @@ export function createMarket(deps: {
       // The one part of a manifest that is not inert: these are spawned when a
       // file of a matching type opens, so the answer is about them.
       runs: result.extension.servers.map(server => server.command.join(' ')),
-      ...(installed ? { current: installed.version } : null),
     })
+  }
+
+  /**
+   * Install every pending update, no questions asked. Failures are reported and
+   * skipped — one unreachable manifest must not hold the rest back — except when
+   * `quiet`: the startup check runs uninvited, and an editor that reports a
+   * failed background request on every launch is worse than one that says
+   * nothing.
+   */
+  const applyUpdates = async (
+    pending: { entry: MarketEntry; current: string }[],
+    quiet = false,
+  ): Promise<void> => {
+    const updated: MarketEntry[] = []
+    let servers = false
+    for (const { entry: found } of pending) {
+      const result = await fetchExtension(found.id, { registry: registry(), fetcher })
+      if (!result.ok) {
+        if (!quiet) status.say(`Extension ${found.id}: ${result.error}`, 'error')
+        continue
+      }
+      const error = await writeExtension(found.id, result, EXTENSIONS_DIR, {
+        registry: registry(),
+        fetcher,
+      })
+      if (error) {
+        if (!quiet) status.say(`Could not update ${found.id}: ${error}`, 'error')
+        continue
+      }
+      servers ||= result.extension.servers.length > 0
+      updated.push(found)
+    }
+    if (updated.length === 0) return
+    settings.reloadExtensions()
+    status.say(
+      updated.length === 1
+        ? `Updated ${updated[0]!.name} to ${updated[0]!.version}`
+        : `Updated ${updated.length} extensions`,
+    )
+    // After the confirmation, as in `accept`: the restart re-syncs the open
+    // documents, and what a new server has to say about them should land on
+    // top of the line saying the update happened, not under it.
+    if (servers) onServersReload?.()
   }
 
   /**
@@ -199,11 +242,7 @@ export function createMarket(deps: {
       return void status.say('Could not reach the extension market', 'warn')
     }
     const pending = updates()
-    if (pending.length > 0) {
-      return void status.say(
-        `${pending.length} extension update${pending.length === 1 ? '' : 's'} available`,
-      )
-    }
+    if (pending.length > 0) return applyUpdates(pending)
     status.say(
       before === 0
         ? `Extension market: ${fresh.length} extension${fresh.length === 1 ? '' : 's'}`
@@ -215,10 +254,7 @@ export function createMarket(deps: {
     await refresh(true)
     const pending = updates()
     if (pending.length === 0) return void status.say('Every extension is up to date')
-    // One prompt at a time: each manifest is fetched and confirmed on its own,
-    // and the palette command is how the next one is reached. A queue of modals
-    // would be worse than a list.
-    await offer(pending[0]!.entry.id, `Update ${pending[0]!.entry.name}?`)
+    await applyUpdates(pending)
   }
 
   /**
@@ -261,18 +297,12 @@ export function createMarket(deps: {
     }
   }
 
-  /** The startup pass: refresh, report updates, then offer what the config wants. */
+  /** The startup pass: refresh, apply updates, then offer what the config wants. */
   const check = async (): Promise<void> => {
     if (!settings.config.extensionUpdates) return
     await ready()
     const pending = updates()
-    if (pending.length > 0) {
-      status.say(
-        pending.length === 1
-          ? `${pending[0]!.entry.name} ${pending[0]!.entry.version} is out — palette → Extensions`
-          : `${pending.length} extension updates available — palette → Extensions`,
-      )
-    }
+    if (pending.length > 0) await applyUpdates(pending, true)
     suggestMissingNames()
   }
 

--- a/src/app/prompts.ts
+++ b/src/app/prompts.ts
@@ -522,15 +522,15 @@ export function createPromptHandlers(deps: {
         }
       case 'installExtension':
         return {
-          title: p.current ? 'Extension update' : 'Extension available',
-          verb: p.current ? 'update it' : 'install it',
+          title: 'Extension available',
+          verb: 'install it',
           danger: false,
           // The commands are the part worth reading before agreeing: a manifest
           // is data and installing it runs nothing, but a language server is a
           // program druk will spawn the next time a matching file opens.
           message: [
             p.why,
-            `${p.name} adds ${p.summary}${p.current ? ` (${p.current} installed)` : ''}.`,
+            `${p.name} adds ${p.summary}.`,
             p.runs.length > 0 ? `It runs: ${p.runs.join(', ')}` : '',
           ]
             .filter(Boolean)

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -122,9 +122,10 @@ export type Prompt =
   | { kind: 'uninstallServer'; id: string; name: string; packages: string[] }
   /**
    * A market extension is worth installing. `why` is what raised it (a file whose
-   * language has no server, a config naming a theme nothing registers, or an
-   * update), and `runs` names the commands the extension would have druk spawn —
-   * the one thing about a manifest that is not inert.
+   * language has no server, or a config naming a theme nothing registers), and
+   * `runs` names the commands the extension would have druk spawn — the one
+   * thing about a manifest that is not inert. Only ever a first install: an
+   * update of something already installed applies itself without a prompt.
    */
   | {
       kind: 'installExtension'
@@ -133,8 +134,6 @@ export type Prompt =
       summary: string
       why: string
       runs: string[]
-      /** The version installed now, when this is an update rather than a first install. */
-      current?: string
     }
   /**
    * Delete an installed extension. `servers` names the language servers druk

--- a/src/extensions/builtin.ts
+++ b/src/extensions/builtin.ts
@@ -2,10 +2,10 @@
  * The extensions that ship inside the binary.
  *
  * Same manifests as the market's — these are `extensions/<id>/extension.json` in this
- * repository, imported as JSON so `bun build --compile` inlines them. Nothing
- * else distinguishes a preinstalled extension: it is listed, it can be disabled,
- * and installing the market's copy of the same id replaces it, which is how a
- * built-in extension gets an update.
+ * repository, imported as JSON so `bun build --compile` inlines them. A
+ * preinstalled extension is listed and can be disabled like any other, but it is
+ * part of the binary: it updates with druk itself, so the market never offers it
+ * an update and a disk copy of the same id never replaces it.
  *
  * What is here is a judgement about a first run: the languages most projects
  * open, so a fresh druk highlights code with no network and no installs. Every

--- a/src/extensions/index.ts
+++ b/src/extensions/index.ts
@@ -7,8 +7,9 @@
  * under `$XDG_CONFIG_HOME/druk/extensions/`, or a bare `<name>.json` in that folder
  * for one that needs no files at all. A project may carry its own in
  * `<project>/.druk/extensions/`, the way it carries its own settings. `./builtin.ts`
- * holds the manifests compiled into the binary; a copy on disk with the same id
- * replaces one of those, which is how the market updates it.
+ * holds the manifests compiled into the binary; those always win over a disk copy
+ * of the same id, because a built-in updates with druk itself, never through the
+ * market.
  *
  * Data, deliberately. Installing an extension runs no code, so a shared theme pack
  * is as safe to drop in as a config file, and the compiled binary needs no
@@ -121,11 +122,19 @@ export function loadExtensions(
     const extension = parsed.extension
     if (!extension) continue
     const held = found.get(extension.id)
-    // Shadowing a built-in is the update path — the market's copy of an extension
-    // druk ships is how it gets a newer version — but two on disk is a mistake
-    // someone has to be told about, since which one wins is a directory listing.
-    if (held && !held.builtin) {
-      problems.push({ source, reason: `"${extension.id}" is already loaded from ${held.source}` })
+    // A built-in updates with druk itself, so a copy on disk can only be stale —
+    // loading it would pin the extension at whatever version was once fetched,
+    // and every druk update after that would silently not apply. Skipped and
+    // named, so the leftover (druk used to update built-ins through the market)
+    // can be deleted. Two market copies stay a mistake to report, since which
+    // one wins is a directory listing.
+    if (held) {
+      problems.push({
+        source,
+        reason: held.builtin
+          ? `"${extension.id}" ships with druk and updates with it — delete this copy`
+          : `"${extension.id}" is already loaded from ${held.source}`,
+      })
       continue
     }
     found.set(extension.id, extension)

--- a/test/extensions.test.tsx
+++ b/test/extensions.test.tsx
@@ -166,20 +166,25 @@ test('a manifest that is both a theme pack and a language is refused', () => {
   expect(problems[0]?.reason).toContain('one or the other')
 })
 
-test('an extension on disk replaces the built-in of the same id', () => {
-  // The update path: druk ships a typescript extension, and the market's copy of it
-  // — or a hand-written one — is what takes over.
+test('a built-in wins over an extension on disk of the same id', () => {
+  // A built-in updates with druk itself, so a disk copy — a leftover from when
+  // the market updated built-ins, or a hand-written one — can only be stale.
+  // Loading it would pin the extension at that version through every druk update.
   install({
     id: 'typescript',
     version: '9.0.0',
     languageServers: [{ id: 'typescript', command: ['deno', 'lsp'], filetypes: ['typescript'] }],
   })
   const { extensions: found, problems } = loadExtensions(fixture({}))
-  expect(problems).toEqual([])
-  expect(resolveServer('typescript', {})?.command).toEqual(['deno', 'lsp'])
+  // Named rather than silently skipped: deleting the copy is on whoever owns it.
+  expect(problems[0]?.reason).toContain('ships with druk')
+  expect(resolveServer('typescript', {})?.command).toEqual([
+    'typescript-language-server',
+    '--stdio',
+  ])
   const shipped = found.filter(extension => extension.id === 'typescript')
   expect(shipped).toHaveLength(1)
-  expect(shipped[0]?.builtin).toBe(false)
+  expect(shipped[0]?.builtin).toBe(true)
 })
 
 test('a project carries its own extensions', () => {

--- a/test/market-ui.test.tsx
+++ b/test/market-ui.test.tsx
@@ -154,6 +154,31 @@ test('an installed extension with a newer version in the market is reported at s
   await untilFrame(t, 'Go 1.1.0 is out')
 })
 
+test('a built-in is never an update, however new the market copy', async () => {
+  // typescript ships inside the binary and updates with druk itself, so a newer
+  // catalog version of it must not count as an extension update.
+  catalog = {
+    extensions: [
+      {
+        id: 'typescript',
+        name: 'TypeScript',
+        version: '9.9.9',
+        description: 'TypeScript and friends',
+        provides: { themes: [], icons: [], filetypes: ['typescript'] },
+      },
+    ],
+  }
+  const dir = fixture({ 'a.ts': 'const a = 1\n' })
+  const t = await launch(dir, { extensionUpdates: true })
+
+  await runCommand(t, 'Check for extension updates')
+  await untilFrame(t, 'Extension market: 1 extension')
+  // The second pass is the assertion: with a catalog already in hand it answers
+  // about updates, and "1 extension update available" is the failure this pins.
+  await runCommand(t, 'Check for extension updates')
+  await untilFrame(t, 'Every extension is up to date')
+})
+
 test('the market is not touched when the setting is off', async () => {
   const dir = fixture({ 'main.go': 'package main\n' })
   const t = await launch(dir, { lsp: true, extensionUpdates: false }, {}, { checkUpdates: true })

--- a/test/market-ui.test.tsx
+++ b/test/market-ui.test.tsx
@@ -145,13 +145,17 @@ test('declining is remembered, and asks again for no other file of that language
   expect(t.captureCharFrame()).not.toContain('No language server')
 })
 
-test('an installed extension with a newer version in the market is reported at startup', async () => {
+test('an installed extension with a newer version in the market updates itself at startup', async () => {
   install({ ...GO_EXTENSION, version: '1.0.0' })
   const dir = fixture({ 'a.ts': 'const a = 1\n' })
   loadExtensions(dir)
   const t = await launch(dir, { extensionUpdates: true }, {}, { checkUpdates: true })
 
-  await untilFrame(t, 'Go 1.1.0 is out')
+  await untilFrame(t, 'Updated Go to 1.1.0')
+  // Applied, not only announced: the disk copy is the market's newer manifest.
+  expect(JSON.parse(readFileSync(join(EXTENSIONS_DIR, 'go', 'extension.json'), 'utf8'))).toEqual(
+    GO_EXTENSION,
+  )
 })
 
 test('a built-in is never an update, however new the market copy', async () => {


### PR DESCRIPTION
## What

Two changes to how extension updates work:

**1. Preinstalled (integrated) extensions never receive market updates** — they are part of the binary and update with druk itself.

- `updates()` in `src/app/market.ts` now counts market copies only, so the startup check, "Check for extension updates" and "Update extensions" never touch a built-in.
- The loader no longer lets a disk copy of a built-in's id shadow it. A stale copy would pin the extension at whatever version was once fetched, silently defeating every druk update after that. Such a copy (a leftover from when the market updated built-ins, or a hand-written one) is skipped and reported so it can be deleted.
- The extensions panel already hid the per-row update marker for built-ins; the market now agrees with it.

**2. Updates for market-installed extensions apply automatically.**

- A new `applyUpdates` fetches and writes every pending update, reloads the manifests once, restarts language servers when an update carries any, and reports "Updated Go to 1.1.0" / "Updated N extensions" in the status bar. A failed fetch is reported and skipped so one unreachable manifest doesn't hold the rest back.
- All three discovery paths use it: the startup check (previously a status line pointing at the palette), "Check for extension updates", and "Update extensions" / `u` in the panel (previously one confirm prompt per extension).
- The install confirm is now for first installs only — it exists to name the commands a manifest would have druk spawn, a question already answered when the extension was installed. Its dead update variant (`current`, "Extension update / update it") is removed.
- The uninvited startup pass stays quiet about its own fetch failures, keeping the existing "no background-error status lines on launch" rule.

## Docs

`AGENTS.md`, `ARCHITECTURE.md` (the built-in bullet and the network bullet — startup now fetches update manifests unprompted) and `extensions/README.md` (a bumped `version` reaches users on their next launch; built-ins only via a druk release) updated in the same change.

## Tests

- `test/extensions.test.tsx`: the shadow test now asserts the built-in wins and the stray copy is reported.
- `test/market-ui.test.tsx`: a built-in with a newer catalog version is never an update; the startup test now asserts the update is applied to disk, not just announced.
- `bun run check` passes apart from `test/process.test.ts`, `test/symlink.test.tsx` and `test/vim-visual.test.tsx`, which fail identically on the base commit in this environment (pre-existing, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SgL6CpRcXf8uCdGBqW3nTA

---
_Generated by [Claude Code](https://claude.ai/code/session_01SgL6CpRcXf8uCdGBqW3nTA)_