### PR TITLE
feat(editor): go to the start of the line with Ctrl+Opt+B

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,9 @@ shifted Ctrl chord no terminal can deliver. It exists because a *selection* that
 reaches the end of a line quietly covers the newline as well and the renderer
 paints nothing there, so deleting one that looked like exactly one line pulled the
 line below up onto the line above — [#75](https://github.com/letstri/druk/issues/75)),
+going to the start of the current line (`Ctrl+Opt+B`, palette → Editor → Go to
+beginning of line — Ctrl+E is the textarea's end of line, and Ctrl+A is select-all,
+so the readline pair has no beginning half left; Ctrl+Opt+E already unfolds),
 code folding (`Ctrl+Opt+S` / `Ctrl+Opt+E`, palette → Editor → Fold / Unfold block at
 cursor, and fold/unfold everything: blocks come from indentation rather than from the
 grammar, so they work for the languages druk paints with `patterns` and no tree at

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -781,6 +781,7 @@ export function App(props: {
             history={editor.history()}
             edit={editor.edit()}
             lineOp={editor.lineOp()}
+            lineHome={editor.lineHome()}
             foldOp={editor.foldOp()}
             vim={config.vim}
             cursorStyle={config.cursorStyle}

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -560,6 +560,7 @@ export function createCommands(ctx: AppContext) {
     toggleWrap: settings.toggleWrap,
     toggleSidebarPosition: settings.toggleSidebarPosition,
     lineOp: editor.requestLineOp,
+    lineHome: editor.requestLineHome,
     foldOp: editor.requestFoldOp,
     triggerCompletion: editor.requestCompletion,
     openSettings: () => {

--- a/src/app/commands.ts
+++ b/src/app/commands.ts
@@ -69,6 +69,7 @@ export interface CommandActions {
   previewIcons: (id: string) => void
   restoreIcons: () => void
   lineOp: (op: 'comment' | 'up' | 'down' | 'duplicate' | 'delete') => void
+  lineHome: () => void
   foldOp: (op: FoldOp) => void
   triggerCompletion: () => void
   openSettings: () => void
@@ -508,6 +509,12 @@ export function buildCommands(actions: CommandActions, ctx: CommandContext): Com
           label: 'Duplicate line',
           hint: `${ALT}+Shift+↓`,
           run: () => actions.lineOp('duplicate'),
+        },
+        {
+          id: 'editor.lineStart',
+          label: 'Go to beginning of line',
+          hint: `Ctrl+${ALT}+B`,
+          run: actions.lineHome,
         },
         {
           id: 'editor.deleteLine',

--- a/src/app/editor.ts
+++ b/src/app/editor.ts
@@ -26,6 +26,8 @@ export function createEditorBridge(vim: boolean) {
   } | null>(null)
   /** Folding, the same one-shot shape: the pane owns which blocks are collapsed. */
   const [foldOp, setFoldOp] = createSignal<{ op: FoldOp; key: number } | null>(null)
+  /** Caret to column 0 of the current line — not a lineOp, those rewrite text. */
+  const [lineHome, setLineHome] = createSignal<{ key: number } | null>(null)
   const [cursor, setCursor] = createSignal({ line: 0, col: 0 })
   /**
    * The lines the editor's selection spans, or null while there is none. Only
@@ -51,6 +53,7 @@ export function createEditorBridge(vim: boolean) {
     setLineOp(prev => ({ op, key: (prev?.key ?? 0) + 1 }))
   const requestCompletion = () => setCompletion(prev => ({ key: (prev?.key ?? 0) + 1 }))
   const requestFoldOp = (op: FoldOp) => setFoldOp(prev => ({ op, key: (prev?.key ?? 0) + 1 }))
+  const requestLineHome = () => setLineHome(prev => ({ key: (prev?.key ?? 0) + 1 }))
 
   return {
     vimMode,
@@ -67,6 +70,8 @@ export function createEditorBridge(vim: boolean) {
     requestLineOp,
     foldOp,
     requestFoldOp,
+    lineHome,
+    requestLineHome,
     completion,
     requestCompletion,
     completionOpen,

--- a/src/app/keyboard.ts
+++ b/src/app/keyboard.ts
@@ -81,7 +81,7 @@ export function installKeyboard(ctx: AppContext, actions: CommandActions) {
     'nav.forward': actions.navForward,
     'tabs.closeOthers': actions.closeOthers,
     'tabs.closeAll': actions.closeAll,
-    'editor.lineStart': () => editor.requestLineHome(),
+    'editor.lineStart': actions.lineHome,
     'editor.deleteLine': () => actions.lineOp('delete'),
     'editor.format': actions.formatDocument,
     'editor.formatOpen': actions.formatOpenFiles,

--- a/src/app/keyboard.ts
+++ b/src/app/keyboard.ts
@@ -81,6 +81,7 @@ export function installKeyboard(ctx: AppContext, actions: CommandActions) {
     'nav.forward': actions.navForward,
     'tabs.closeOthers': actions.closeOthers,
     'tabs.closeAll': actions.closeAll,
+    'editor.lineStart': () => editor.requestLineHome(),
     'editor.deleteLine': () => actions.lineOp('delete'),
     'editor.format': actions.formatDocument,
     'editor.formatOpen': actions.formatOpenFiles,

--- a/src/app/keymap.ts
+++ b/src/app/keymap.ts
@@ -79,6 +79,9 @@ export const BINDABLE: Bindable[] = [
   { id: 'nav.forward', label: 'Go forward', defaults: [`Ctrl+${ALT}+Y`] },
   { id: 'tabs.closeOthers', label: 'Close other tabs', defaults: [] },
   { id: 'tabs.closeAll', label: 'Close all tabs', defaults: [] },
+  // B for beginning: Ctrl+A is select-all, Ctrl+E is the textarea's line-end,
+  // and Ctrl+Opt+E already unfolds. Ctrl+Shift+E is the same byte as Ctrl+E.
+  { id: 'editor.lineStart', label: 'Go to beginning of line', defaults: [`Ctrl+${ALT}+B`] },
   // Shrink and expand, since the bracket pair every GUI editor uses for this is
   // Ctrl+Shift+[ / ] — a shifted Ctrl chord no terminal can deliver, and Ctrl+[
   // is the Escape byte anyway. C, the other obvious letter, is Copy path.

--- a/src/ui/EditorPane.tsx
+++ b/src/ui/EditorPane.tsx
@@ -80,6 +80,8 @@ export interface EditorPaneProps {
   edit: { content: string; key: number } | null
   /** A line edit asked for from the palette; bumped `key` re-applies. */
   lineOp: { op: 'comment' | 'up' | 'down' | 'duplicate' | 'delete'; key: number } | null
+  /** Caret to column 0 of the current line; bumped `key` re-applies. */
+  lineHome: { key: number } | null
   /** A fold asked for from the palette or a chord; bumped `key` re-applies. */
   foldOp: { op: FoldOp; key: number } | null
   vim: boolean
@@ -1976,6 +1978,19 @@ export function EditorPane(props: EditorPaneProps) {
           case 'delete':
             return deleteSelectedLines()
         }
+      },
+      { defer: true },
+    ),
+  )
+
+  createEffect(
+    on(
+      () => props.lineHome?.key,
+      () => {
+        if (!props.lineHome || !editor || props.blocked) return
+        editor.gotoLineHome()
+        applyWindow(true)
+        scheduleCursorSync()
       },
       { defer: true },
     ),

--- a/src/ui/keys.ts
+++ b/src/ui/keys.ts
@@ -94,6 +94,13 @@ export const KEYS: KeyInfo[] = [
   { key: 'Ctrl+S', label: 'Save file', section: 'Editing', where: 'editor', ids: ['save'] },
   { key: 'Ctrl+Z / Ctrl+Y', label: 'Undo / redo', section: 'Editing', where: 'editor' },
   { key: 'Ctrl+A', label: 'Select all', section: 'Editing', where: 'editor' },
+  {
+    key: `Ctrl+${ALT}+B`,
+    label: 'Go to beginning of line',
+    section: 'Editing',
+    where: 'editor',
+    ids: ['editor.lineStart'],
+  },
   { key: 'Ctrl+C', label: 'Copy selection — quits if none', section: 'Editing', where: 'all' },
   { key: 'Ctrl+X / Ctrl+V', label: 'Cut / paste', section: 'Editing', where: 'editor' },
   { key: 'Ctrl+/ · Ctrl+L', label: 'Toggle comment', section: 'Editing', where: 'editor' },

--- a/test/help-scroll.test.tsx
+++ b/test/help-scroll.test.tsx
@@ -29,7 +29,7 @@ test('on a short terminal the table windows instead of clipping the footer', asy
 test('a tall terminal shows every section with the plain footer', async () => {
   // Exactly the height the whole table needs: the overlay draws a window of
   // `height - 7` lines, so a row added to `KEYS` costs a row here too.
-  const t = await openHelp(80)
+  const t = await openHelp(82)
   const frame = t.captureCharFrame()
 
   for (const section of [

--- a/test/help-scroll.test.tsx
+++ b/test/help-scroll.test.tsx
@@ -29,7 +29,7 @@ test('on a short terminal the table windows instead of clipping the footer', asy
 test('a tall terminal shows every section with the plain footer', async () => {
   // Exactly the height the whole table needs: the overlay draws a window of
   // `height - 7` lines, so a row added to `KEYS` costs a row here too.
-  const t = await openHelp(82)
+  const t = await openHelp(81)
   const frame = t.captureCharFrame()
 
   for (const section of [

--- a/test/line-start.test.tsx
+++ b/test/line-start.test.tsx
@@ -1,0 +1,46 @@
+import { expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { fixture, launch, openFile, press, runCommand } from './helpers'
+
+const CONTENT = 'const a = 1\n  const b = 2\n'
+
+/** Ctrl+Opt+B: Opt is an ESC prefix ahead of the Ctrl byte. */
+const CTRL_OPT_B = `\x1B${String.fromCharCode(2)}`
+
+async function opened() {
+  const dir = fixture({ 'a.ts': CONTENT })
+  const t = await launch(dir)
+  await openFile(t, 'a.ts')
+  return { t, dir }
+}
+
+const save = (t: Awaited<ReturnType<typeof opened>>['t']) =>
+  press(t, i => i.pressKey('s', { ctrl: true }))
+
+/** Down onto the indented line, then to its end — the caret opens at the top. */
+const toEndOfSecondLine = async (t: Awaited<ReturnType<typeof opened>>['t']) => {
+  await press(t, i => i.pressArrow('down'))
+  await press(t, i => i.pressKey('e', { ctrl: true }))
+}
+
+test('Ctrl+Opt+B goes to column 0 of the current line', async () => {
+  const { t, dir } = await opened()
+  await toEndOfSecondLine(t)
+  await press(t, i => void i.pressKeys([CTRL_OPT_B]))
+  await press(t, i => void i.typeText('x'))
+  await save(t)
+
+  expect(readFileSync(join(dir, 'a.ts'), 'utf8')).toBe('const a = 1\nx  const b = 2\n')
+})
+
+test('the palette command does the same', async () => {
+  const { t, dir } = await opened()
+  await toEndOfSecondLine(t)
+  await runCommand(t, 'beginning of line')
+  await press(t, i => void i.typeText('x'))
+  await save(t)
+
+  expect(readFileSync(join(dir, 'a.ts'), 'utf8')).toBe('const a = 1\nx  const b = 2\n')
+})


### PR DESCRIPTION
## Summary
- Adds `Ctrl+Opt+B` (palette → Editor → Go to beginning of line) so the caret jumps to column 0 of the current line.
- Closes the gap from #81: `Ctrl+E` already goes to the end of the line, but `Ctrl+A` is select-all and `Ctrl+Opt+E` unfolds.
- Home/End are unchanged.

Closes #81

## Test plan
- [ ] Open a file, move to the middle of a line, press `Ctrl+Opt+B` — caret lands at column 0 of that line, not the start of the file
- [ ] `Ctrl+E` still goes to the end of the line; `Ctrl+A` still selects all
- [ ] Palette → Editor → Go to beginning of line does the same jump
- [ ] Help / Ctrl+K lists the new chord; Settings can rebind `editor.lineStart`
- [ ] `Ctrl+Opt+E` still unfolds