### PR TITLE
perf(git): take the last synchronous refresh queries off the event loop

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -628,20 +628,27 @@ is just a diff against the empty tree.
   rules as they walk into it, and `git.activeRepo()` — panel cursor, then open file, then
   the only one — is the cwd every command runs in. That last one is why `gitOp` hands the
   repository to its callback instead of letting callers look it up again.
-- **git queries are synchronous, mutations are not.** `core/git.ts` runs `diff`,
-  `status` and `rev-parse`/`rev-list` with `spawnSync` — they sit behind the gutter and
-  tree marks and finish in milliseconds. Everything that writes (commit, push, stash,
-  checkout, merge, branch create/rename/delete) goes through the async `mutate`, because a
-  push talks to the network and would freeze the TUI for its duration. `createGitOp`
+- **Refresh queries run off the event loop; mutations always did.** `spawnSync` blocks
+  the loop for the subprocess's whole life, and every keystroke and mouse move waits it
+  out — on a large repository, long enough to read as a freeze. So everything on a
+  refresh cadence — `diff`, `status`, `check-ignore` and the `rev-parse`/`rev-list` pair
+  behind the status bar's branch and counts — goes through `gitAsync`, and each answer is
+  behind a generation counter in `wireGitEffects`: they land out of order, and an earlier
+  pass answering after a newer one would repaint marks the newer one has already
+  replaced. The synchronous `git` is left for the one-shot calls a keystroke asks for
+  outright — `statusMap` for the commit picker, `currentBranch` for the comparison's own
+  lookups — where there is no cadence to fall behind. Everything that writes (commit,
+  push, stash, checkout, merge, branch create/rename/delete) goes through the async
+  `mutate` for the same reason twice over: a push talks to the network. `createGitOp`
   serialises them, and anything that rewrites the working tree passes a `touchesTree`
   strategy so open buffers are pulled back from disk rather than waiting for the watcher.
   Pulls, stashes and branch operations use clash-safe whole-tree sync; a confirmed
   file-level discard forces only the paths belonging to that row to follow disk, because
   the confirmation has already authorized losing their unsaved buffers.
-- **Branch comparison is the one read-only query that runs off the render thread.** A
-  branch's worth of changed files is more than a frame's worth of subprocess, so its five
-  queries go through `gitAsync` rather than the synchronous `git` every other query uses.
-  All of them are NUL-delimited (`-z`), because a path may contain a tab or a newline and
+- **Branch comparison's queries are NUL-delimited.** Its five go through `gitAsync` like
+  every other read — a branch's worth of changed files was never a frame's worth of
+  subprocess, which is why these were the first to move off the loop.
+  All of them are `-z`, because a path may contain a tab or a newline and
   the default output C-quotes it; a truncated record fails the whole read rather than
   dropping a row, which would read as "this file did not change". Blobs are fetched by
   object ID only once a row is opened. `app/comparison.ts` drops stale generations and
@@ -657,18 +664,19 @@ is just a diff against the empty tree.
   reports ENOBUFS, which every caller in `core/git.ts` reads as "no output" — `status` in a
   repository with thousands of changed files would silently become "nothing changed" and
   the tree would show no marks. The helper raises `maxBuffer`.
-- **The multi-repository status refresh is the exception to that.** `statusMapAsync`
-  exists because the refresh runs one status query *per repository*: a folder of twenty
-  checkouts is forty subprocesses, and synchronously that is a visible freeze on every
-  save and every filesystem event. They run at once and a generation counter drops an
-  earlier pass that answers late. The synchronous `statusMap` stays for the commit
+- **The status refresh is one query per repository.** `statusMapAsync` exists because a
+  folder of twenty checkouts is forty subprocesses, and synchronously that was a visible
+  freeze on every save and every filesystem event. They run at once and a generation
+  counter drops an earlier pass that answers late. The synchronous `statusMap` stays for the commit
   picker, which asks about one repository on demand; both share their parsers, because a
   file the two disagreed about would be a row that cannot be committed.
-- **git waits for the first frame.** Every query is a synchronous subprocess, and
-  effects run inside the initial render pass, so `wireGitEffects` sits behind one
-  deferred tick and `branch` starts null — `statusMap` alone can take hundreds of
-  milliseconds in a large repository, all of it otherwise spent before anything is on
-  screen. The marks and branch appear a beat later; nothing else changes cadence.
+- **git waits for the first frame.** Every query is a subprocess, and effects run inside
+  the initial render pass, so `wireGitEffects` sits behind one deferred tick and `branch`
+  starts null — `status` alone can take hundreds of milliseconds in a large repository,
+  all of it otherwise spent before anything is on screen. The marks and branch appear a
+  beat later; nothing else changes cadence. It follows that a test asserting on a mark
+  has to poll for it (`until`) rather than read the frame `launch` returns — none of the
+  queries has answered by then.
 - **The diff page is a snapshot, and something has to refresh it.** `workspace.diffTab`
   holds one file's two texts as they read when it opened, so a commit, stash or save
   leaves it showing changes that are gone — `App` re-runs `actions.refreshDiff` on

--- a/src/app/git.ts
+++ b/src/app/git.ts
@@ -383,7 +383,7 @@ export function runCommit(
       // may have sat in a confirm while the active repository changed under it.
       const branch = currentBranch(repo)
       if (!branch) return { ok: true, detail: 'Committed — no branch to push' }
-      const hasUpstream = upstreamOf(repo)?.name != null
+      const hasUpstream = (await upstreamOf(repo))?.name != null
       pushed = { branch, hasUpstream }
       if (opts.variant === 'commitPush') return push(repo, branch, hasUpstream)
       // Sync on a branch origin has never seen is a publish, VS Code's own turn.
@@ -456,9 +456,25 @@ export function wireGitEffects(deps: {
     }
   }
 
+  /**
+   * Which pass's answer wins, one counter per query. Every query below is
+   * asynchronous, so a burst can land an earlier pass's result after a newer
+   * one's — and the clearing branches count too, or a diff still in flight would
+   * repaint marks for the file that was just closed.
+   */
+  let linesRun = 0
+  let upstreamRun = 0
+
   const refreshLines = deferred(() => {
     const path = workspace.activePath()
-    git.setGitLines(path ? diffLines(path, git.diffBase()) : new Map())
+    const run = ++linesRun
+    if (!path) {
+      git.setGitLines(new Map())
+      return
+    }
+    void diffLines(path, git.diffBase()).then(lines => {
+      if (run === linesRun) git.setGitLines(lines)
+    })
   })
 
   createEffect(
@@ -472,17 +488,24 @@ export function wireGitEffects(deps: {
 
   const refreshUpstream = deferred(() => {
     const repo = git.activeRepo()
-    const upstream = repo ? upstreamOf(repo) : null
-    git.setUpstream(upstream)
-    // The sync sections measure the same distance, so they move on its cadence.
-    git.setSyncCommits(
-      repo && upstream?.name != null
-        ? {
-            incoming: upstreamCommits(repo, 'incoming'),
-            outgoing: upstreamCommits(repo, 'outgoing'),
-          }
-        : { incoming: [], outgoing: [] },
-    )
+    const run = ++upstreamRun
+    void (async () => {
+      const upstream = repo ? await upstreamOf(repo) : null
+      if (run !== upstreamRun) return
+      // Published before the log below rather than with it: the status bar's
+      // counts are two subprocesses cheaper than the panel's rows, and waiting
+      // for those would hold the arrows back on every branch change.
+      git.setUpstream(upstream)
+      // The sync sections measure the same distance, so they move on its cadence.
+      const [incoming, outgoing] =
+        repo && upstream?.name != null
+          ? await Promise.all([
+              upstreamCommits(repo, 'incoming'),
+              upstreamCommits(repo, 'outgoing'),
+            ])
+          : [[], []]
+      if (run === upstreamRun) git.setSyncCommits({ incoming, outgoing })
+    })()
   })
 
   // Ahead/behind only moves when history does, so it is deliberately not tied to

--- a/src/core/git.ts
+++ b/src/core/git.ts
@@ -36,10 +36,12 @@ export function combinedStatus(entry: StatusEntry): FileStatus {
 }
 
 /**
- * Queries run synchronously (`git`) — they sit behind the gutter marks, tree marks
- * and status bar, and finish in milliseconds. Mutations run through `mutate`,
- * asynchronously: a push or fetch talks to the network and would freeze the whole
- * TUI for its duration if awaited on the render thread's clock.
+ * Everything on a refresh path — the gutter marks, the tree marks, the status
+ * bar's branch and counts — runs through `gitAsync`: `spawnSync` blocks the event
+ * loop for the subprocess's whole life, which on a large repository is input the
+ * terminal does not answer. `git` (synchronous) is left for the one-shot calls a
+ * user's own keystroke asks for. Mutations run through `mutate`, asynchronously
+ * for the same reason twice over: a push or fetch talks to the network.
  *
  * `spawnSync` truncates at 1 MB by default and reports ENOBUFS, which every caller
  * here reads as "no output" — `status` would lose files in a large repository.
@@ -57,9 +59,9 @@ function git(cwd: string, args: string[], timeout = 5000, input?: string) {
 }
 
 /**
- * `git` off the render thread, for the comparison queries — the synchronous
- * `git` above would stall a frame for as long as the subprocess takes, which on
- * a branch's worth of files is not a frame's worth of time.
+ * `git` off the render thread — the synchronous `git` above would stall a frame
+ * for as long as the subprocess takes, which on a branch's worth of files, or a
+ * repository large enough for `status` to take its time, is not a frame's worth.
  */
 function gitAsync(cwd: string, args: string[], timeout = 10_000): Promise<ProcessResult> {
   return runProcess('git', args, { cwd, timeout, maxOutput: MAX_OUTPUT })
@@ -70,9 +72,12 @@ function gitAsync(cwd: string, args: string[], timeout = 10_000): Promise<Proces
  * Returns an empty map outside a repository, for untracked files, or when git is
  * unavailable.
  */
-export function diffLines(path: string, ref: string | null = null): Map<number, LineChange> {
+export async function diffLines(
+  path: string,
+  ref: string | null = null,
+): Promise<Map<number, LineChange>> {
   const marks = new Map<number, LineChange>()
-  const run = git(
+  const run = await gitAsync(
     dirname(path),
     ['diff', '--no-color', '--unified=0', ...(ref ? [ref] : []), '--', path],
     3000,
@@ -106,7 +111,15 @@ export function diffLines(path: string, ref: string | null = null): Map<number, 
  * must never reach `git push --set-upstream`.
  */
 export function currentBranch(cwd: string): string | null {
-  const run = git(cwd, ['rev-parse', '--abbrev-ref', 'HEAD'], 3000)
+  return branchName(git(cwd, ['rev-parse', '--abbrev-ref', 'HEAD'], 3000))
+}
+
+/** `currentBranch` off the render thread, for the queries that are already async. */
+async function currentBranchAsync(cwd: string): Promise<string | null> {
+  return branchName(await gitAsync(cwd, ['rev-parse', '--abbrev-ref', 'HEAD'], 3000))
+}
+
+function branchName(run: { status: number | null; stdout: string }): string | null {
   if (run.status !== 0) return null
   const branch = run.stdout.trim()
   return branch.length > 0 && branch !== 'HEAD' ? branch : null
@@ -1012,18 +1025,18 @@ export interface Upstream {
  * worst, one outside a repository — the status bar asks for this often enough
  * that a `currentBranch` call on top of them is worth avoiding.
  */
-export function upstreamOf(cwd: string): Upstream | null {
-  const ref = git(cwd, ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{u}'])
+export async function upstreamOf(cwd: string): Promise<Upstream | null> {
+  const ref = await gitAsync(cwd, ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{u}'])
   if (ref.status !== 0) {
     // No upstream and no repository look the same here; the branch tells them apart.
     // Ahead/behind stay 0: with nothing to compare against there is no distance to
     // report, and a repo with no remote at all must not show a phantom ↑.
-    return currentBranch(cwd) ? { name: null, ahead: 0, behind: 0 } : null
+    return (await currentBranchAsync(cwd)) ? { name: null, ahead: 0, behind: 0 } : null
   }
 
   // Status checked, and NaN floored: a failed count would otherwise put "NaN↓"
   // on the status bar — `[''].map(Number)` is `[NaN]`, which `?? 0` keeps.
-  const counts = git(cwd, ['rev-list', '--left-right', '--count', '@{u}...HEAD'])
+  const counts = await gitAsync(cwd, ['rev-list', '--left-right', '--count', '@{u}...HEAD'])
   const [behind, ahead] = counts.status === 0 ? counts.stdout.trim().split(/\s+/).map(Number) : []
   return { name: ref.stdout.trim(), ahead: ahead || 0, behind: behind || 0 }
 }
@@ -1037,12 +1050,16 @@ const SYNC_LOG_CAP = 50
  * measure against, and capped: a branch hundreds of commits adrift is a wall of
  * rows the header's counts already summarise.
  */
-export function upstreamCommits(
+export async function upstreamCommits(
   cwd: string,
   direction: 'incoming' | 'outgoing',
-): { oid: string; subject: string }[] {
+): Promise<{ oid: string; subject: string }[]> {
   const range = direction === 'incoming' ? 'HEAD..@{upstream}' : '@{upstream}..HEAD'
-  const run = git(cwd, ['log', '-n', String(SYNC_LOG_CAP), '--format=%H %s', range], 5000)
+  const run = await gitAsync(
+    cwd,
+    ['log', '-n', String(SYNC_LOG_CAP), '--format=%H %s', range],
+    5000,
+  )
   if (run.status !== 0) return []
   return run.stdout
     .split('\n')

--- a/src/core/git.ts
+++ b/src/core/git.ts
@@ -1062,7 +1062,11 @@ export interface Upstream {
  * that a `currentBranch` call on top of them is worth avoiding.
  */
 export async function upstreamOf(cwd: string): Promise<Upstream | null> {
-  const ref = await gitAsync(cwd, ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{u}'])
+  const ref = await gitAsync(
+    cwd,
+    ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{u}'],
+    5000,
+  )
   if (ref.status !== 0) {
     // No upstream and no repository look the same here; the branch tells them apart.
     // Ahead/behind stay 0: with nothing to compare against there is no distance to
@@ -1072,7 +1076,7 @@ export async function upstreamOf(cwd: string): Promise<Upstream | null> {
 
   // Status checked, and NaN floored: a failed count would otherwise put "NaN↓"
   // on the status bar — `[''].map(Number)` is `[NaN]`, which `?? 0` keeps.
-  const counts = await gitAsync(cwd, ['rev-list', '--left-right', '--count', '@{u}...HEAD'])
+  const counts = await gitAsync(cwd, ['rev-list', '--left-right', '--count', '@{u}...HEAD'], 5000)
   const [behind, ahead] = counts.status === 0 ? counts.stdout.trim().split(/\s+/).map(Number) : []
   return { name: ref.stdout.trim(), ahead: ahead || 0, behind: behind || 0 }
 }

--- a/test/git.test.tsx
+++ b/test/git.test.tsx
@@ -14,7 +14,7 @@ import {
   statusMap,
 } from '../src/core/git'
 import { THEMES } from '../src/themes'
-import { launch, press, settle } from './helpers'
+import { launch, press, settle, until } from './helpers'
 import type { Harness } from './helpers'
 
 /** A real repository with one committed file. */
@@ -32,29 +32,29 @@ function repo(committed: string) {
   return dir
 }
 
-test('marks modified and added lines', () => {
+test('marks modified and added lines', async () => {
   const dir = repo('one\ntwo\nthree\n')
   writeFileSync(join(dir, 'a.ts'), 'one\nCHANGED\nthree\nfour\n')
 
-  const marks = diffLines(join(dir, 'a.ts'))
+  const marks = await diffLines(join(dir, 'a.ts'))
   expect(marks.get(1)).toBe('modified') // "two" -> "CHANGED"
   expect(marks.get(3)).toBe('added') // new final line
   expect(marks.get(0)).toBeUndefined() // untouched
 })
 
-test('a hunk that grows marks rewrites and additions separately', () => {
+test('a hunk that grows marks rewrites and additions separately', async () => {
   const dir = repo('one\ntwo\n')
   writeFileSync(join(dir, 'a.ts'), 'one\nCHANGED\nEXTRA\n')
 
-  const marks = diffLines(join(dir, 'a.ts'))
+  const marks = await diffLines(join(dir, 'a.ts'))
   expect(marks.get(1)).toBe('modified')
   expect(marks.get(2)).toBe('added')
 })
 
-test('is empty outside a repository', () => {
+test('is empty outside a repository', async () => {
   const dir = mkdtempSync(join(tmpdir(), 'druk-'))
   writeFileSync(join(dir, 'a.ts'), 'x\n')
-  expect(diffLines(join(dir, 'a.ts')).size).toBe(0)
+  expect((await diffLines(join(dir, 'a.ts'))).size).toBe(0)
   expect(currentBranch(dir)).toBeNull()
 })
 
@@ -76,10 +76,15 @@ test('status marks reach the file tree', async () => {
   writeFileSync(join(dir, 'fresh.ts'), 'new\n') // untracked
 
   const t = await launch(dir)
-  const frame = t.captureCharFrame()
-  const row = (name: string) => frame.split('\n').find(line => line.includes(name)) ?? ''
+  const row = (name: string) =>
+    t
+      .captureCharFrame()
+      .split('\n')
+      .find(line => line.includes(name)) ?? ''
 
-  expect(row('a.ts')).toContain('M')
+  // Polled: the status queries are subprocesses off the render thread, so the
+  // first frame is drawn before any of them has answered.
+  await until(t, () => row('a.ts').includes('M'))
   expect(row('fresh.ts')).toContain('U')
 })
 
@@ -91,11 +96,12 @@ test('a folder inherits the status of its contents', async () => {
   // Rendered, not just statusMap()'d: the inheritance lives in FileTree.statusOf,
   // and git reports `?? sub/` on its own, so the map alone proves nothing.
   const t = await launch(dir)
-  const row = t
-    .captureCharFrame()
-    .split('\n')
-    .find(line => line.includes('sub'))!
-  expect(row).toContain('U')
+  const row = () =>
+    t
+      .captureCharFrame()
+      .split('\n')
+      .find(line => line.includes('sub')) ?? ''
+  await until(t, () => row().includes('U'))
 })
 
 test('a path git has to quote still gets its mark', () => {


### PR DESCRIPTION
`diffLines` runs on every save and reload; `upstreamOf` and `upstreamCommits` run on every branch, revision and active-repository change. All three spawned git synchronously, so the event loop — and with it every keystroke and mouse move — was blocked for as long as the subprocess took. On a large repository that reads as a freeze. `statusEntries`, `currentBranch` and `ignoredIn` in `refreshStatus`, and the OS-appearance poll, were converted earlier; these were what was left.

## What changed

- `diffLines`, `upstreamOf` and `upstreamCommits` (`src/core/git.ts`) go through `gitAsync`, keeping their existing timeouts. The parsing bodies are untouched.
- `refreshLines` and `refreshUpstream` (`src/app/git.ts`) each get their own generation counter, the pattern `refreshStatus` already uses: a burst can land an earlier pass's answer after a newer one's. The branches that clear the signals bump the counter as well, or a diff still in flight would repaint marks for the file that was just closed.
- `refreshUpstream` publishes `setUpstream` as soon as it lands, ahead of the two `upstreamCommits` logs (now run together), so the status bar's arrows are not held back by the panel's sync sections on every branch change.
- `upstreamOf`'s no-upstream branch called the synchronous `currentBranch`, which would have left one blocking spawn on the path. `currentBranchAsync` is the async twin and `branchName` the parse they share; the synchronous `currentBranch` stays for the one-shot calls a user's keystroke asks for.
- The commit flow's `upstreamOf` call is now awaited — it was already inside an async `gitOp` callback.

No sync/async twins were kept for the three converted queries: nothing else called them, so a sync copy would be dead code.

## Tests

`test/git.test.tsx` awaits `diffLines`, and the two tree-mark tests that asserted on the first frame now poll with `until` — the marks arrive after that frame now that every status query is off-thread.

`bun run check` passes on types, lint and format, and the suite passes except `test/goto.test.tsx` "go to definition opens where the server points". That test fails only in full-suite runs, passes solo (including under artificial CPU load), and fails identically on a stashed baseline — a full suite run without these changes reproduces it, so it predates this branch. That baseline run also flaked `test/outside-git.test.tsx`, which passes three-for-three here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)