### PR TITLE
Wait for the pointer to rest before drawing a tooltip

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -613,13 +613,18 @@ whole-pane focus clicks are not buttons, so they get no tint.
 A chrome button also carries a tooltip: `useTooltip` (`src/ui/tooltip.ts`) is `useHover`
 plus a `ref` and the id of the command the button runs, and `TooltipLayer` (mounted by
 `App.tsx`, gated on the `tooltips` setting) draws whatever is registered. A tooltip is
-that command's chord and nothing else — hovering gives one button's, holding Ctrl or Cmd
-for half a second lights every registered button's at once. No labels either way: each of
-these buttons is already on screen with its own name or glyph, so a box reading `Files`
-under a button labelled `Files` would be a box saying nothing. The chord comes from
-`chordFor`, so a rebind renames a tooltip and an unbound command has none at all — which
-is the intended shape, not a gap: binding one is what brings its tooltip back. Six things
-are load-bearing:
+that command's chord and nothing else — resting the pointer on one button gives that
+button's, holding Ctrl or Cmd for half a second lights every registered button's at once.
+Both halves wait: a chip drawn the moment the pointer crossed a button would flash chord
+after chord as the mouse travelled the tab strip on its way to the editor, so hovering
+counts out a dwell of its own (`DWELL_MS`), re-counted from the start on each button the
+pointer reaches. The *tint* is not delayed — that is the button answering the pointer, and
+one that took half a second to admit it is a button would read as a dead cell. No labels
+either way: each of these buttons is already on screen with its own name or glyph, so a
+box reading `Files` under a button labelled `Files` would be a box saying nothing. The
+chord comes from `chordFor`, so a rebind renames a tooltip and an unbound command has none
+at all — which is the intended shape, not a gap: binding one is what brings its tooltip
+back. Six things are load-bearing:
 
 - **The peek needs the kitty keyboard protocol**, which is why `src/main.tsx` asks for
   `events` *and* `allKeysAsEscapes`: a modifier is reported as a key of its own only when

--- a/src/ui/tooltip.ts
+++ b/src/ui/tooltip.ts
@@ -9,8 +9,12 @@
  * `Files` under a button labelled `Files` is a box saying nothing. Two ways in,
  * showing the same thing:
  *
- * - Hovering one button gives that button's chord.
+ * - Resting the pointer on one button gives that button's chord.
  * - Holding Ctrl (or Cmd) for half a second lights every button's chord at once.
+ *
+ * Both halves are a *pause*: a chip that appeared the instant the pointer
+ * crossed a button would flash chord after chord as the mouse travelled the tab
+ * strip on its way to the editor.
  *
  * It follows that a command with no chord in force has no tooltip at all, and
  * that binding one is what brings it back.
@@ -61,6 +65,70 @@ const [hovered, setHovered] = createSignal<number | null>(null)
 const [held, setHeld] = createSignal(false)
 
 /**
+ * How long the pointer has to rest on a button before its chord is drawn. The
+ * peek's own hold is what this is to hovering: a tooltip is an answer to a
+ * question, and crossing a button on the way somewhere else is not asking one.
+ */
+const DWELL_MS = 400
+
+/**
+ * The last target whose dwell counted out. Paired with `hovered` rather than
+ * read alone — see `resting`.
+ */
+const [dwelled, setDwelled] = createSignal<number | null>(null)
+let dwell: ReturnType<typeof setTimeout> | null = null
+
+const clearDwell = () => {
+  if (dwell) clearTimeout(dwell)
+  dwell = null
+}
+
+/**
+ * The target to annotate: the pointer is on it *and* it has counted out there.
+ * Two signals rather than one because leaving has to hide the chip at once while
+ * the count it earned outlives the turn — see `leave`.
+ */
+const resting = () => {
+  const at = hovered()
+  return at !== null && at === dwelled() ? at : null
+}
+
+function enter(id: number) {
+  if (hovered() === id) return
+  clearDwell()
+  setHovered(id)
+  // The pointer that never really left this button (below) keeps the chord it
+  // already earned rather than counting a second time under a reader's eyes.
+  if (dwelled() === id) return
+  setDwelled(null)
+  dwell = setTimeout(() => {
+    dwell = null
+    setDwelled(id)
+  }, DWELL_MS)
+}
+
+/**
+ * Conditional: crossing onto the next control can deliver its `over` before this
+ * one's `out`, and clearing unconditionally would erase the new state — the
+ * pending dwell along with it.
+ *
+ * The count is forgotten a turn later rather than here. Moving the pointer
+ * between two texts inside one button delivers the row an `out` and the next
+ * `over` in the same turn, and forgetting synchronously would blink the chip
+ * away and start it counting again mid-button; a microtask lands after both, so
+ * only a pointer that is still off every target forgets. It is not a delay —
+ * `resting` already went null with `hovered`, so the chip is gone this frame.
+ */
+function leave(id: number) {
+  if (hovered() !== id) return
+  clearDwell()
+  setHovered(null)
+  queueMicrotask(() => {
+    if (hovered() === null) setDwelled(null)
+  })
+}
+
+/**
  * The `tooltips` setting, pushed in by `App`. It lives here rather than staying
  * a prop on the layer because the peek is more than the boxes: the buttons light
  * up with it, and a component asking "am I lit?" must get `false` from the same
@@ -95,10 +163,7 @@ export function useTooltip(command: string | (() => string) | undefined) {
 
   onCleanup(() => {
     targets.delete(id)
-    // Not `setHovered(null)`: the pointer has usually already arrived somewhere
-    // else by the time a row is torn down, and clearing unconditionally would
-    // erase the new state.
-    setHovered(cur => (cur === id ? null : cur))
+    leave(id)
     bump(at => at + 1)
   })
 
@@ -109,10 +174,14 @@ export function useTooltip(command: string | (() => string) | undefined) {
      * peek. Lighting the buttons is what ties a peek's chords to the things they
      * run — the boxes sit on the rows above or below, and a column of chords
      * beside a strip of unmarked buttons says nothing about which is which.
+     *
+     * Not delayed the way the chip is: the tint is the button answering the
+     * pointer, and a control that takes half a second to admit it is one reads
+     * as a dead cell.
      */
     lit: () => hovered() === id || (peeking() && chord() !== ''),
-    enter: () => setHovered(id),
-    leave: () => setHovered(cur => (cur === id ? null : cur)),
+    enter: () => enter(id),
+    leave: () => leave(id),
     ref: (node: TargetBox) => {
       box = node
     },
@@ -120,16 +189,16 @@ export function useTooltip(command: string | (() => string) | undefined) {
 }
 
 /**
- * What to draw now: nothing unless the pointer is on a target or the peek is up,
- * and nothing for a control whose command has no key — a chord is all a tooltip
- * ever says, so with no chord there is nothing to say. A command left unbound
- * therefore costs its button a tooltip, which is the right way round: binding
- * one gives it back.
+ * What to draw now: nothing unless the pointer has rested on a target or the
+ * peek is up, and nothing for a control whose command has no key — a chord is
+ * all a tooltip ever says, so with no chord there is nothing to say. A command
+ * left unbound therefore costs its button a tooltip, which is the right way
+ * round: binding one gives it back.
  */
 export function tooltipAnchors(): TooltipAnchor[] {
   version()
   if (!enabled()) return []
-  const at = hovered()
+  const at = resting()
   const peek = peeking()
   const anchors: TooltipAnchor[] = []
 

--- a/test/tooltips.test.tsx
+++ b/test/tooltips.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, test } from 'bun:test'
 import { ui } from '../src/themes'
 import { ALT } from '../src/ui/keys'
 import { placeTooltips } from '../src/ui/tooltipLayout'
-import { fixture, launch, openFile, settle, until } from './helpers'
+import { fixture, launch, openFile, settle, until, untilFrame } from './helpers'
 import type { Harness } from './helpers'
 
 /** A theme colour as the captured spans report one. */
@@ -48,6 +48,17 @@ const release = (t: Harness) => t.renderer.stdin.emit('data', Buffer.from(`\x1B[
 /** Long enough for the hold to have counted out. */
 const HELD = 700
 
+/** Long enough for the hover dwell to have counted out, had it been going to. */
+const RESTED = 600
+
+/** Point at `text` and wait out the dwell the tooltip only appears after. */
+async function rest(t: Harness, text: string) {
+  const at = cellOf(t, text)
+  await t.mockMouse.moveTo(at.x, at.y)
+  await settle(t, RESTED)
+  return at
+}
+
 const kitty = { kittyKeyboard: true }
 
 /**
@@ -56,6 +67,7 @@ const kitty = { kittyKeyboard: true }
  */
 const TIP = ' Ctrl+G '
 const GIT_TIP = ` Ctrl+${ALT}+G `
+const EXT_TIP = ` Ctrl+${ALT}+X `
 
 describe('tooltip placement', () => {
   test('a control near the top is annotated below it, one near the bottom above', () => {
@@ -121,10 +133,8 @@ describe('hover tooltips', () => {
   test('a status bar button gives its key, and says nothing else — the label is on it already', async () => {
     const t = await launch(fixture({ 'a.ts': 'const a = 1\n' }))
     await openFile(t, 'a.ts')
-    const at = cellOf(t, 'Ln 1')
     expect(t.captureCharFrame()).not.toContain(TIP)
-    await t.mockMouse.moveTo(at.x, at.y)
-    await settle(t)
+    await rest(t, 'Ln 1')
     expect(t.captureCharFrame()).toContain(TIP)
     expect(t.captureCharFrame()).not.toContain('Go to line')
   })
@@ -134,10 +144,44 @@ describe('hover tooltips', () => {
     // With a file open: the welcome screen lists chords too, and this is looking
     // for one of them by its spelling.
     await openFile(t, 'a.ts')
+    await rest(t, 'Git')
+    expect(t.captureCharFrame()).toContain(GIT_TIP)
+  })
+
+  test('nothing is drawn until the pointer has rested there', async () => {
+    const t = await launch(fixture({ 'a.ts': 'const a = 1\n' }))
+    await openFile(t, 'a.ts')
     const at = cellOf(t, 'Git')
     await t.mockMouse.moveTo(at.x, at.y)
-    await settle(t)
+    await settle(t, 100)
+    expect(t.captureCharFrame()).not.toContain(GIT_TIP)
+    await untilFrame(t, GIT_TIP)
+  })
+
+  test('a pointer only passing over a button says nothing at all', async () => {
+    const t = await launch(fixture({ 'a.ts': 'const a = 1\n' }))
+    await openFile(t, 'a.ts')
+    const at = cellOf(t, 'Git')
+    await t.mockMouse.moveTo(at.x, at.y)
+    await settle(t, 100)
+    // On past it, the way a mouse crosses the strip on its way to the editor.
+    await t.mockMouse.moveTo(60, 10)
+    await settle(t, RESTED)
+    expect(t.captureCharFrame()).not.toContain(GIT_TIP)
+  })
+
+  test('moving to the next button counts that one out from the start', async () => {
+    const t = await launch(fixture({ 'a.ts': 'const a = 1\n' }))
+    await openFile(t, 'a.ts')
+    await rest(t, 'Git')
     expect(t.captureCharFrame()).toContain(GIT_TIP)
+    const ext = cellOf(t, 'Ext')
+    await t.mockMouse.moveTo(ext.x, ext.y)
+    await settle(t, 100)
+    const frame = t.captureCharFrame()
+    expect(frame).not.toContain(GIT_TIP)
+    expect(frame).not.toContain(EXT_TIP)
+    await untilFrame(t, EXT_TIP)
   })
 
   test('a hover chip sits against its button, not shifted off a neighbour', async () => {
@@ -155,9 +199,7 @@ describe('hover tooltips', () => {
     await until(t, () => t.captureCharFrame().includes('▴'))
     await openFile(t, 'a.ts')
 
-    const at = cellOf(t, 'Ext')
-    await t.mockMouse.moveTo(at.x, at.y)
-    await settle(t)
+    const at = await rest(t, 'Ext')
     const tip = `Ctrl+${ALT}+X`
     const tipRow = t
       .captureCharFrame()
@@ -171,9 +213,7 @@ describe('hover tooltips', () => {
     // With a file open: the welcome screen lists chords too, and this is looking
     // for one of them by its spelling.
     await openFile(t, 'a.ts')
-    const at = cellOf(t, 'Git')
-    await t.mockMouse.moveTo(at.x, at.y)
-    await settle(t)
+    await rest(t, 'Git')
     expect(spanBg(t, GIT_TIP)).toBe(rgb(ui.statusBg))
     // The tooltip must not read as part of the pane it floats over.
     expect(spanBg(t, GIT_TIP)).not.toBe(rgb(ui.bg))
@@ -186,9 +226,7 @@ describe('hover tooltips', () => {
     // bindable command holds a key for it.
     await openFile(t, 'a.ts')
     const before = t.captureCharFrame()
-    const at = cellOf(t, 'Files')
-    await t.mockMouse.moveTo(at.x, at.y)
-    await settle(t)
+    await rest(t, 'Files')
     expect(t.captureCharFrame()).toBe(before)
   })
 
@@ -197,22 +235,32 @@ describe('hover tooltips', () => {
     // With a file open: the welcome screen lists chords too, and this is looking
     // for one of them by its spelling.
     await openFile(t, 'a.ts')
-    const at = cellOf(t, 'Git')
-    await t.mockMouse.moveTo(at.x, at.y)
-    await settle(t)
+    await rest(t, 'Git')
     expect(t.captureCharFrame()).toContain(GIT_TIP)
-    // Into the editor, which is nobody's button.
+    // Into the editor, which is nobody's button. No dwell on the way out: the
+    // chip goes with the pointer.
     await t.mockMouse.moveTo(60, 10)
     await settle(t)
     expect(t.captureCharFrame()).not.toContain(GIT_TIP)
   })
 
+  test('a button come back to counts out again', async () => {
+    const t = await launch(fixture({ 'a.ts': 'const a = 1\n' }))
+    await openFile(t, 'a.ts')
+    const at = await rest(t, 'Git')
+    expect(t.captureCharFrame()).toContain(GIT_TIP)
+    await t.mockMouse.moveTo(60, 10)
+    await settle(t)
+    await t.mockMouse.moveTo(at.x, at.y)
+    await settle(t, 100)
+    expect(t.captureCharFrame()).not.toContain(GIT_TIP)
+    await untilFrame(t, GIT_TIP)
+  })
+
   test('nothing is drawn while the setting is off', async () => {
     const t = await launch(fixture({ 'a.ts': 'const a = 1\n' }), { tooltips: false })
     await openFile(t, 'a.ts')
-    const at = cellOf(t, 'Git')
-    await t.mockMouse.moveTo(at.x, at.y)
-    await settle(t)
+    await rest(t, 'Git')
     expect(t.captureCharFrame()).not.toContain(GIT_TIP)
   })
 })


### PR DESCRIPTION
A hover tooltip appeared the instant the pointer crossed a button, so a mouse travelling the tab strip on its way to the editor flashed chord after chord. The Ctrl/Cmd peek already waits out a hold; hovering now counts out a dwell of its own.

## What changed

- `src/ui/tooltip.ts`: `DWELL_MS = 400`. `tooltipAnchors` draws for `resting()` — the pointer is on a target *and* has counted out there — rather than for `hovered()`. Each button the pointer reaches counts from the start, so passing over three on the way to a fourth shows only the fourth.
- The hover **tint** is deliberately not delayed: that is the button answering the pointer, and one that took half a second to admit it is a button would read as a dead cell. `lit()` is unchanged.
- The state is two signals rather than one. Leaving hides the chip on the same frame, but the count a target earned is forgotten a microtask later: moving the pointer between two `<text>` children of one button delivers the row an `out` and the next `over` in the same turn, and forgetting synchronously would blink the chip away and restart the count mid-button, under a reader's eyes.
- The peek is untouched, and `tooltips: false` still turns the whole thing off.

## Tests

`test/tooltips.test.tsx` grows a `rest()` helper (point, then wait the dwell out) in place of the instant `settle()`, plus four cases: nothing before the dwell, a pointer only passing over says nothing at all, moving to the next button counts that one out from the start, and a button come back to counts again. 22 pass.

`AGENTS.md`'s tooltip paragraph now states the dwell and why the tint is exempt.

## Verification

`bun run check` — types, lint and format clean. Three test files fail in this container — `test/process.test.ts`, `test/symlink.test.tsx`, `test/vim-visual.test.tsx` — and all four failures reproduce identically on the base commit: a symlink fixture hitting ENOENT under this container's `/tmp`, a clipboard-dependent vim case, and a 5s spawn timeout. They are environment failures, not this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGKADuFFywUzn7zGcjgfKJ)_