### PR TITLE
Sweep the temp directories the git tests leave behind

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -783,12 +783,20 @@ harness exists to encode:
 - **Poll for what you are waiting for.** `until()` renders until a condition holds, so a
   watcher event or an async highlight costs what it actually takes. A fixed
   `settle(t, 400)` is right only when the assertion is that *nothing* happened.
-- **A fixture lives as long as its file.** `test/setup.ts` deletes every `fixture()`
+- **A fixture lives as long as its file.** `test/setup.ts` deletes every registered
   directory in a global `afterAll`, so nothing may expect one to outlive the file that
   made it. The sweep is not tidiness: a full run creates some three thousand temp
   projects, and when they accumulated across runs the temp folder reached ~100k
   entries, every `mkdtemp` in it slowed down, and whole files began timing out and
   being killed — which reads as flaky tests and is not.
+- **A temp directory comes from `tempDir()` (`test/temp.ts`), never from `mkdtempSync`.**
+  Only what `tempDir` made is in the swept set, so a raw `mkdtempSync` leaks for good —
+  the `repo()` helpers of the git tests each did one and left 60k directories behind,
+  until two of those files began failing with `ENOENT` on their own fixture files. It
+  takes the name prefix (`tempDir('druk-git-')`) and lives in its own module rather than
+  in `helpers.tsx` so a unit test can have it without pulling in `<App/>`; `fixture()` is
+  built on it. A helper that nests (a base holding `origin.git`, `mine` and `theirs`)
+  registers the outermost directory and joins onto it.
 
 `captureCharFrame()` returns text only — selection and focus are background colors, so
 assert on something textual (a prompt appearing, the status bar, file contents on disk).

--- a/test/binary.test.tsx
+++ b/test/binary.test.tsx
@@ -1,13 +1,13 @@
 import { expect, test } from 'bun:test'
-import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { launch, openFile, press, settle } from './helpers'
+import { tempDir } from './temp'
 
 /** A project with a real binary file next to a text one. */
 function project() {
-  const dir = mkdtempSync(join(tmpdir(), 'druk-'))
+  const dir = tempDir()
   writeFileSync(join(dir, '.DS_Store'), Buffer.from([0, 1, 2, 0, 3, 4]))
   writeFileSync(join(dir, 'main.ts'), 'const a = 1\n')
   return dir

--- a/test/boundaries.test.ts
+++ b/test/boundaries.test.ts
@@ -36,3 +36,22 @@ test('ui/ and the feature folders never import from app/', () => {
   }
   expect(offenders).toEqual([])
 })
+
+/**
+ * A raw `mkdtempSync` is invisible to the sweep in `test/setup.ts` and leaks for
+ * good: the git helpers each made one and left tens of thousands of directories
+ * behind, until `mkdtemp` in that folder slowed down and files began failing with
+ * `ENOENT` on their own fixtures.
+ */
+test('tests take their temp directories from tempDir()', () => {
+  const dir = import.meta.dir
+  const offenders: string[] = []
+  for (const name of readdirSync(dir)) {
+    if (name === 'temp.ts' || !/\.tsx?$/.test(name)) continue
+    const source = readFileSync(join(dir, name), 'utf8')
+    for (const [line, text] of source.split('\n').entries()) {
+      if (/\bmkdtempSync\s*\(/.test(text)) offenders.push(`${name}:${line + 1}: ${text.trim()}`)
+    }
+  }
+  expect(offenders).toEqual([])
+})

--- a/test/branch-comparison.test.tsx
+++ b/test/branch-comparison.test.tsx
@@ -1,7 +1,6 @@
 import { expect, test } from 'bun:test'
 import { execFileSync } from 'node:child_process'
-import { mkdtempSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import {
@@ -13,9 +12,10 @@ import {
   untilFrame,
   untilGone,
 } from './helpers'
+import { tempDir } from './temp'
 
 function repo() {
-  const dir = mkdtempSync(join(tmpdir(), 'druk-compare-ui-'))
+  const dir = tempDir('druk-compare-ui-')
   const git = (...args: string[]) =>
     execFileSync('git', args, { cwd: dir, encoding: 'utf8' }).trim()
   git('init', '-q', '-b', 'trunk')

--- a/test/bulk-ui.test.tsx
+++ b/test/bulk-ui.test.tsx
@@ -1,14 +1,14 @@
 import { describe, expect, test } from 'bun:test'
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { launch, press, settle } from './helpers'
 import type { Harness } from './helpers'
+import { tempDir } from './temp'
 
 /** A folder with enough entries that the delete spans several frames. */
 function project(packages: number) {
-  const dir = mkdtempSync(join(tmpdir(), 'druk-bulkui-'))
+  const dir = tempDir('druk-bulkui-')
   writeFileSync(join(dir, 'a.ts'), 'const a = 1\n')
   for (let index = 0; index < packages; index++) {
     mkdirSync(join(dir, 'node_modules', `pkg-${index}`), { recursive: true })

--- a/test/bulk.test.ts
+++ b/test/bulk.test.ts
@@ -1,14 +1,14 @@
 import { describe, expect, test } from 'bun:test'
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { copyAll, moveAll, removeAll } from '../src/core/bulk'
 import type { BulkProgress } from '../src/core/bulk'
+import { tempDir } from './temp'
 
 /** A directory of `count` packages, each with a file inside — a small node_modules. */
 function heavyDir(count: number) {
-  const base = mkdtempSync(join(tmpdir(), 'druk-bulk-'))
+  const base = tempDir('druk-bulk-')
   const dir = join(base, 'node_modules')
   for (let index = 0; index < count; index++) {
     mkdirSync(join(dir, `pkg-${index}`), { recursive: true })

--- a/test/change-track.test.tsx
+++ b/test/change-track.test.tsx
@@ -1,12 +1,12 @@
 import { describe, expect, test } from 'bun:test'
 import { execFileSync } from 'node:child_process'
-import { mkdtempSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { ui } from '../src/themes'
 import { fixture, launch, openFile, press, settle } from './helpers'
 import type { Harness } from './helpers'
+import { tempDir } from './temp'
 
 const SOURCE = `${Array.from({ length: 400 }, (_, index) => `const value${index} = ${index}`).join(
   '\n',
@@ -31,7 +31,7 @@ const track = (t: Harness) => {
 }
 
 async function repoWith(edit: (lines: string[]) => void) {
-  const dir = mkdtempSync(join(tmpdir(), 'druk-track-'))
+  const dir = tempDir('druk-track-')
   const git = (...args: string[]) => execFileSync('git', args, { cwd: dir })
   git('init', '-q', '-b', 'main')
   git('config', 'user.email', 'test@example.com')
@@ -92,7 +92,7 @@ describe('the track agrees with the scrollbar', () => {
   ).join('\n')}\n`
 
   async function wrappedRepo(changeAt: number) {
-    const dir = mkdtempSync(join(tmpdir(), 'druk-wrapped-'))
+    const dir = tempDir('druk-wrapped-')
     const git = (...args: string[]) => execFileSync('git', args, { cwd: dir })
     git('init', '-q', '-b', 'main')
     git('config', 'user.email', 'test@example.com')

--- a/test/comparison-controller.test.tsx
+++ b/test/comparison-controller.test.tsx
@@ -1,7 +1,6 @@
 import { expect, test } from 'bun:test'
 import { execFileSync } from 'node:child_process'
-import { mkdtempSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { createRoot } from 'solid-js'
@@ -9,9 +8,10 @@ import { createRoot } from 'solid-js'
 import { createComparison } from '../src/app/comparison'
 import { createGit } from '../src/app/git'
 import { createStatus } from '../src/app/status'
+import { tempDir } from './temp'
 
 function repo() {
-  const dir = mkdtempSync(join(tmpdir(), 'druk-controller-'))
+  const dir = tempDir('druk-controller-')
   const git = (...args: string[]) =>
     execFileSync('git', args, { cwd: dir, encoding: 'utf8' }).trim()
   git('init', '-q', '-b', 'trunk')

--- a/test/diff-tab.test.tsx
+++ b/test/diff-tab.test.tsx
@@ -1,15 +1,15 @@
 import { expect, test } from 'bun:test'
 import { execFileSync } from 'node:child_process'
-import { mkdtempSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { launch, openDiff, openFile, press, pressTimes, runCommand, untilFrame } from './helpers'
 import type { Harness } from './helpers'
+import { tempDir } from './temp'
 
 /** A repository with two committed, then modified, files. */
 function repo() {
-  const dir = mkdtempSync(join(tmpdir(), 'druk-difftab-'))
+  const dir = tempDir('druk-difftab-')
   const git = (...args: string[]) => execFileSync('git', args, { cwd: dir })
   git('init', '-q', '-b', 'main')
   git('config', 'user.email', 'test@example.com')

--- a/test/diff-view.test.tsx
+++ b/test/diff-view.test.tsx
@@ -1,7 +1,6 @@
 import { expect, test } from 'bun:test'
 import { execFileSync } from 'node:child_process'
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { mkdirSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { HATCH } from '../src/ui/DiffView'
@@ -16,6 +15,7 @@ import {
   untilFrame,
   untilGone,
 } from './helpers'
+import { tempDir } from './temp'
 
 interface Span {
   text: string
@@ -24,7 +24,7 @@ interface Span {
 
 /** A real repository with committed files. */
 function repo(files: Record<string, string>) {
-  const dir = mkdtempSync(join(tmpdir(), 'druk-diff-'))
+  const dir = tempDir('druk-diff-')
   const git = (...args: string[]) => execFileSync('git', args, { cwd: dir })
   git('init', '-q', '-b', 'main')
   git('config', 'user.email', 'test@example.com')
@@ -353,7 +353,7 @@ test('the palette opens over the diff, and Ctrl+W closes the page', async () => 
 })
 
 test('a long path is cut from the left so the hints stay on screen', async () => {
-  const dir = mkdtempSync(join(tmpdir(), 'druk-diff-'))
+  const dir = tempDir('druk-diff-')
   const git = (...args: string[]) => execFileSync('git', args, { cwd: dir })
   git('init', '-q', '-b', 'main')
   git('config', 'user.email', 'test@example.com')

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, test } from 'bun:test'
-import { chmodSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { chmodSync, mkdirSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { FILE_TOKEN, formatArgs, formatterFor, resolveBin, runFormatter } from '../src/core/format'
+import { tempDir } from './temp'
 
 /** A command whose script file sees the target path as argv[2], as real ones do. */
 function script(code: string): { command: string[]; dir: string } {
-  const dir = mkdtempSync(join(tmpdir(), 'druk-fmt-'))
+  const dir = tempDir('druk-fmt-')
   const file = join(dir, 'tool.js')
   writeFileSync(file, code)
   return { command: [process.execPath, file], dir }
@@ -78,7 +78,7 @@ describe('formatArgs', () => {
 
 /** A project whose `node_modules/.bin` holds an executable `name`. */
 function projectWithBin(name: string, code: string): string {
-  const dir = mkdtempSync(join(tmpdir(), 'druk-proj-'))
+  const dir = tempDir('druk-proj-')
   const bin = join(dir, 'node_modules', '.bin')
   mkdirSync(bin, { recursive: true })
   const file = join(bin, name)
@@ -94,7 +94,7 @@ describe('resolveBin', () => {
   })
 
   test('a name the project did not install is left to PATH', () => {
-    const dir = mkdtempSync(join(tmpdir(), 'druk-proj-'))
+    const dir = tempDir('druk-proj-')
     expect(resolveBin('gofmt', dir)).toBe('gofmt')
   })
 

--- a/test/formula.test.ts
+++ b/test/formula.test.ts
@@ -1,12 +1,13 @@
 import { afterAll, expect, test } from 'bun:test'
 import { createHash } from 'node:crypto'
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
+
+import { tempDir } from './temp'
 
 const root = join(import.meta.dir, '..')
 // Never the repo's own dist/, for the reason release-notices.test.ts gives.
-const dist = mkdtempSync(join(tmpdir(), 'druk-formula-'))
+const dist = tempDir('druk-formula-')
 afterAll(() => rmSync(dist, { recursive: true, force: true }))
 
 const TARGETS = ['darwin-arm64', 'darwin-x64', 'linux-arm64', 'linux-x64'] as const

--- a/test/git-branch.test.tsx
+++ b/test/git-branch.test.tsx
@@ -1,16 +1,16 @@
 import { expect, test } from 'bun:test'
 import { execFileSync } from 'node:child_process'
-import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { listBranches } from '../src/core/git'
 import { fixture, launch, press, pressEscape, runCommand, settle } from './helpers'
 import type { Harness } from './helpers'
+import { tempDir } from './temp'
 
 /** A repository with one commit on `main`, plus whatever extra branches. */
 function repo(...branches: string[]) {
-  const dir = mkdtempSync(join(tmpdir(), 'druk-branch-'))
+  const dir = tempDir('druk-branch-')
   const git = (...args: string[]) => execFileSync('git', args, { cwd: dir })
   git('init', '-q', '-b', 'main')
   git('config', 'user.email', 'test@example.com')
@@ -46,7 +46,7 @@ test('listBranches marks the current branch and reads upstreams', () => {
     ]),
   )
 
-  const bare = mkdtempSync(join(tmpdir(), 'druk-bare-'))
+  const bare = tempDir('druk-bare-')
   execFileSync('git', ['init', '-q', '--bare', bare])
   execFileSync('git', ['remote', 'add', 'origin', bare], { cwd: dir })
   execFileSync('git', ['push', '-q', '--set-upstream', 'origin', 'main'], { cwd: dir })

--- a/test/git-commands.test.tsx
+++ b/test/git-commands.test.tsx
@@ -1,15 +1,15 @@
 import { expect, test } from 'bun:test'
 import { execFileSync } from 'node:child_process'
-import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { fixture, launch, press, runCommand, settle } from './helpers'
 import type { Harness } from './helpers'
+import { tempDir } from './temp'
 
 /** A real repository with one committed file. */
 function repo(committed: string) {
-  const dir = mkdtempSync(join(tmpdir(), 'druk-git-'))
+  const dir = tempDir('druk-git-')
   const git = (...args: string[]) => execFileSync('git', args, { cwd: dir })
   git('init', '-q', '-b', 'main')
   git('config', 'user.email', 'test@example.com')
@@ -147,7 +147,7 @@ test('stash reverts the working tree and pop brings it back', async () => {
 
 test('push sets an upstream on a local bare remote, and fetch succeeds after', async () => {
   const dir = repo('one\n')
-  const bare = mkdtempSync(join(tmpdir(), 'druk-bare-'))
+  const bare = tempDir('druk-bare-')
   execFileSync('git', ['init', '-q', '--bare', bare])
   execFileSync('git', ['remote', 'add', 'origin', bare], { cwd: dir })
 

--- a/test/git-commit-box.test.tsx
+++ b/test/git-commit-box.test.tsx
@@ -1,11 +1,11 @@
 import { expect, test } from 'bun:test'
 import { execFileSync } from 'node:child_process'
-import { mkdtempSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { fixture, launch, press, pressEscape, runCommand, settle, until } from './helpers'
 import type { Harness } from './helpers'
+import { tempDir } from './temp'
 
 const ESC = String.fromCharCode(27)
 /** Ctrl+Opt+G as terminals spell it: an ESC prefix ahead of Ctrl+G (0x07). */
@@ -31,7 +31,7 @@ function repo() {
  * the shape where sync's pull half and push half both have work to do.
  */
 function behindWithEdit() {
-  const base = mkdtempSync(join(tmpdir(), 'druk-sync-'))
+  const base = tempDir('druk-sync-')
   const origin = join(base, 'origin.git')
   execFileSync('git', ['init', '-q', '--bare', '-b', 'main', origin])
 

--- a/test/git-comparison.test.tsx
+++ b/test/git-comparison.test.tsx
@@ -1,7 +1,6 @@
 import { expect, test } from 'bun:test'
 import { execFileSync } from 'node:child_process'
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import {
@@ -11,9 +10,10 @@ import {
   loadBranchComparison,
   resolveComparison,
 } from '../src/core/git'
+import { tempDir } from './temp'
 
 function repo(initial = 'trunk') {
-  const dir = mkdtempSync(join(tmpdir(), 'druk-compare-'))
+  const dir = tempDir('druk-compare-')
   const git = (...args: string[]) =>
     execFileSync('git', args, { cwd: dir, encoding: 'utf8' }).trim()
   git('init', '-q', '-b', initial)
@@ -107,7 +107,7 @@ test('comparison refuses detached HEAD without calling it an invalid branch', as
 })
 
 test('comparison distinguishes an unborn current branch', async () => {
-  const dir = mkdtempSync(join(tmpdir(), 'druk-compare-unborn-'))
+  const dir = tempDir('druk-compare-unborn-')
   execFileSync('git', ['init', '-q', '-b', 'feature'], { cwd: dir })
 
   const result = await resolveComparison(dir, 'trunk')

--- a/test/git-discard.test.ts
+++ b/test/git-discard.test.ts
@@ -1,15 +1,15 @@
 import { describe, expect, test } from 'bun:test'
 import { execFileSync } from 'node:child_process'
-import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { discardChange, discardTarget } from '../src/core/git'
+import { tempDir } from './temp'
 
 const git = (cwd: string, ...args: string[]) => execFileSync('git', args, { cwd, encoding: 'utf8' })
 
 function repo(files: Record<string, string> = { 'a.txt': 'base\n', 'other.txt': 'other\n' }) {
-  const dir = mkdtempSync(join(tmpdir(), 'druk-discard-'))
+  const dir = tempDir('druk-discard-')
   git(dir, 'init', '-q', '-b', 'main')
   git(dir, 'config', 'user.email', 'druk@test')
   git(dir, 'config', 'user.name', 'druk')
@@ -75,7 +75,7 @@ describe('discardChange', () => {
   })
 
   test('handles an addition on an unborn branch without resolving HEAD', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'druk-discard-unborn-'))
+    const dir = tempDir('druk-discard-unborn-')
     git(dir, 'init', '-q', '-b', 'main')
     writeFileSync(join(dir, '新 file.txt'), 'new\n')
     git(dir, 'add', '新 file.txt')

--- a/test/git-footer.test.tsx
+++ b/test/git-footer.test.tsx
@@ -1,11 +1,11 @@
 import { describe, expect, test } from 'bun:test'
 import { execFileSync } from 'node:child_process'
-import { mkdtempSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { launch, until } from './helpers'
 import type { Harness } from './helpers'
+import { tempDir } from './temp'
 
 /**
  * druk runs no git commands of its own any more, so everything here is set up with
@@ -15,7 +15,7 @@ const git = (cwd: string, ...args: string[]) => execFileSync('git', args, { cwd 
 
 /** A bare "remote" plus clones of it, so ahead/behind are real. */
 function remoteSetup() {
-  const base = mkdtempSync(join(tmpdir(), 'druk-footer-'))
+  const base = tempDir('druk-footer-')
   const origin = join(base, 'origin.git')
   execFileSync('git', ['init', '-q', '--bare', '-b', 'main', origin])
 

--- a/test/git-push.test.tsx
+++ b/test/git-push.test.tsx
@@ -1,10 +1,10 @@
 import { expect, test } from 'bun:test'
 import { execFileSync } from 'node:child_process'
-import { mkdtempSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { launch, press, pressEscape, runCommand, until } from './helpers'
+import { tempDir } from './temp'
 
 const git = (cwd: string, ...args: string[]) => execFileSync('git', args, { cwd })
 
@@ -14,7 +14,7 @@ const git = (cwd: string, ...args: string[]) => execFileSync('git', args, { cwd 
  * rejected in, so it is the shape the offer has to be tested against.
  */
 function diverged() {
-  const base = mkdtempSync(join(tmpdir(), 'druk-push-'))
+  const base = tempDir('druk-push-')
   const origin = join(base, 'origin.git')
   execFileSync('git', ['init', '-q', '--bare', '-b', 'main', origin])
 

--- a/test/git-sync-sections.test.tsx
+++ b/test/git-sync-sections.test.tsx
@@ -1,11 +1,11 @@
 import { expect, test } from 'bun:test'
 import { execFileSync } from 'node:child_process'
-import { mkdtempSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { launch, press, pressEscape, until, untilFrame } from './helpers'
 import type { Harness } from './helpers'
+import { tempDir } from './temp'
 
 const ESC = String.fromCharCode(27)
 /** Ctrl+Opt+G as terminals spell it: an ESC prefix ahead of Ctrl+G (0x07). */
@@ -18,7 +18,7 @@ const git = (cwd: string, ...args: string[]) => execFileSync('git', args, { cwd 
  * sync section — with a clean working tree, so the sections are all there is.
  */
 function adrift() {
-  const base = mkdtempSync(join(tmpdir(), 'druk-adrift-'))
+  const base = tempDir('druk-adrift-')
   const origin = join(base, 'origin.git')
   execFileSync('git', ['init', '-q', '--bare', '-b', 'main', origin])
 

--- a/test/git.test.tsx
+++ b/test/git.test.tsx
@@ -1,7 +1,6 @@
 import { expect, test } from 'bun:test'
 import { execFileSync } from 'node:child_process'
-import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { mkdirSync, symlinkSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import {
@@ -16,10 +15,11 @@ import {
 import { THEMES } from '../src/themes'
 import { launch, press, settle, until } from './helpers'
 import type { Harness } from './helpers'
+import { tempDir } from './temp'
 
 /** A real repository with one committed file. */
 function repo(committed: string) {
-  const dir = mkdtempSync(join(tmpdir(), 'druk-git-'))
+  const dir = tempDir('druk-git-')
   const git = (...args: string[]) => execFileSync('git', args, { cwd: dir })
   git('init', '-q', '-b', 'main')
   git('config', 'user.email', 'test@example.com')
@@ -52,7 +52,7 @@ test('a hunk that grows marks rewrites and additions separately', async () => {
 })
 
 test('is empty outside a repository', async () => {
-  const dir = mkdtempSync(join(tmpdir(), 'druk-'))
+  const dir = tempDir()
   writeFileSync(join(dir, 'a.ts'), 'x\n')
   expect((await diffLines(join(dir, 'a.ts'))).size).toBe(0)
   expect(currentBranch(dir)).toBeNull()
@@ -322,7 +322,7 @@ test('one path beyond a symlink does not blank the whole answer', () => {
 test('ignoredAmong is empty outside a repository', () => {
   // `check-ignore` exits 128 here rather than reporting nothing, and that has to
   // read as "nothing is ignored" — the tree still draws these rows.
-  const dir = mkdtempSync(join(tmpdir(), 'druk-'))
+  const dir = tempDir()
   writeFileSync(join(dir, 'a.ts'), 'x\n')
   expect(ignoredAmong(dir, [join(dir, 'a.ts')]).size).toBe(0)
 })

--- a/test/helpers.tsx
+++ b/test/helpers.tsx
@@ -1,6 +1,5 @@
 import { expect } from 'bun:test'
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { mkdirSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { testRender } from '@opentui/solid'
@@ -10,6 +9,7 @@ import { App } from '../src/app/App'
 import { DEFAULTS } from '../src/core/config'
 import type { Config } from '../src/core/config'
 import { loadExtensions } from '../src/extensions'
+import { tempDir } from './temp'
 
 export type Harness = Awaited<ReturnType<typeof launch>>
 
@@ -39,21 +39,9 @@ export function loadMarketExtensions(): void {
  */
 export const liveHarnesses = new Set<Harness>()
 
-/**
- * Every fixture this process made, deleted when it exits.
- *
- * A run of the suite creates some three thousand of these, and nothing used to
- * remove them: after a few dozen runs the temp folder held ~100k directories and
- * every `mkdtemp` in it slowed down, until whole test files started timing out
- * and being killed. `test/setup.ts` empties this in a global `afterAll` — once
- * per file rather than per test, since a file may hand one fixture to several.
- */
-export const fixtures = new Set<string>()
-
 /** Temp project used by a test. `files` maps relative paths to contents. */
 export function fixture(files: Record<string, string>): string {
-  const dir = mkdtempSync(join(tmpdir(), 'druk-'))
-  fixtures.add(dir)
+  const dir = tempDir()
   for (const [name, content] of Object.entries(files)) {
     const path = join(dir, name)
     mkdirSync(join(path, '..'), { recursive: true })

--- a/test/hidden.test.tsx
+++ b/test/hidden.test.tsx
@@ -1,13 +1,13 @@
 import { describe, expect, test } from 'bun:test'
 import { execFileSync } from 'node:child_process'
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { mkdirSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { listDir } from '../src/core/fs'
 import { ignoredPaths } from '../src/core/git'
 import { listFiles, searchProject } from '../src/core/search'
 import { fixture, launch, toggleSetting } from './helpers'
+import { tempDir } from './temp'
 
 const PROJECT = { 'src/main.ts': 'const a = 1\n', '.DS_Store': 'junk\n', '.gitignore': 'dist\n' }
 
@@ -43,7 +43,7 @@ describe('showDotfiles: false', () => {
 
 describe('respectGitignore: true', () => {
   function repo() {
-    const dir = mkdtempSync(join(tmpdir(), 'druk-ignored-'))
+    const dir = tempDir('druk-ignored-')
     execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: dir })
     writeFileSync(join(dir, '.gitignore'), 'dist\n*.log\n')
     writeFileSync(join(dir, 'a.ts'), 'const a = 1\n')
@@ -99,7 +99,7 @@ describe('respectGitignore: true', () => {
  */
 describe('project search and the fuzzy picker skip ignored files', () => {
   function repo() {
-    const dir = mkdtempSync(join(tmpdir(), 'druk-searchignore-'))
+    const dir = tempDir('druk-searchignore-')
     execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: dir })
     // Deliberately not `dist`: SKIPPED_DIRS drops that by name, which would pass
     // this test without gitignore being consulted at all.
@@ -125,7 +125,7 @@ describe('project search and the fuzzy picker skip ignored files', () => {
   })
 
   test('outside a repository everything is listed', () => {
-    const dir = mkdtempSync(join(tmpdir(), 'druk-searchplain-'))
+    const dir = tempDir('druk-searchplain-')
     writeFileSync(join(dir, '.gitignore'), 'generated\n')
     mkdirSync(join(dir, 'generated'))
     writeFileSync(join(dir, 'generated', 'bundle.js'), 'var alpha = 1\n')
@@ -135,7 +135,7 @@ describe('project search and the fuzzy picker skip ignored files', () => {
 
 describe('the VCS store is not project content', () => {
   function repo() {
-    const dir = mkdtempSync(join(tmpdir(), 'druk-vcs-'))
+    const dir = tempDir('druk-vcs-')
     execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: dir })
     writeFileSync(join(dir, 'a.ts'), 'const a = 1\n')
     writeFileSync(join(dir, '.gitignore'), 'dist\n')
@@ -167,7 +167,7 @@ describe('the VCS store is not project content', () => {
   })
 
   test('a file named like a VCS directory is still a file', () => {
-    const dir = mkdtempSync(join(tmpdir(), 'druk-vcsfile-'))
+    const dir = tempDir('druk-vcsfile-')
     // A worktree or submodule checkout has `.git` as a *file* pointing elsewhere.
     // It is text, and there is no reason to pretend it is not there.
     writeFileSync(join(dir, '.git'), 'gitdir: /elsewhere\n')

--- a/test/image.test.ts
+++ b/test/image.test.ts
@@ -1,16 +1,16 @@
 import { describe, expect, test } from 'bun:test'
-import { mkdtempSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { encode } from 'fast-png'
 
 import { decodeImage, isImagePath, toCells } from '../src/core/image'
 import type { RawImage } from '../src/core/image'
+import { tempDir } from './temp'
 
 /** A PNG on disk with the given RGBA pixels. */
 function pngFixture(width: number, height: number, rgba: number[]): string {
-  const dir = mkdtempSync(join(tmpdir(), 'druk-img-'))
+  const dir = tempDir('druk-img-')
   const path = join(dir, 'img.png')
   writeFileSync(path, encode({ width, height, data: new Uint8Array(rgba), channels: 4 }))
   return path
@@ -45,7 +45,7 @@ describe('decodeImage', () => {
   })
 
   test('throws a readable error on a file that is not an image', () => {
-    const dir = mkdtempSync(join(tmpdir(), 'druk-img-'))
+    const dir = tempDir('druk-img-')
     const path = join(dir, 'fake.png')
     writeFileSync(path, 'not a png at all')
     expect(() => decodeImage(path)).toThrow()

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -3,7 +3,6 @@ import {
   chmodSync,
   cpSync,
   mkdirSync,
-  mkdtempSync,
   readFileSync,
   readdirSync,
   readlinkSync,
@@ -11,14 +10,15 @@ import {
   symlinkSync,
   writeFileSync,
 } from 'node:fs'
-import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+
+import { tempDir } from './temp'
 
 const script = new URL('../install', import.meta.url).pathname
 
 const scratches: string[] = []
 function scratch() {
-  const dir = mkdtempSync(join(tmpdir(), 'druk-install-'))
+  const dir = tempDir('druk-install-')
   scratches.push(dir)
   return dir
 }

--- a/test/long-names.test.tsx
+++ b/test/long-names.test.tsx
@@ -1,11 +1,11 @@
 import { expect, test } from 'bun:test'
 import { execFileSync } from 'node:child_process'
-import { mkdtempSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { fixture, launch, openComparison, press, runCommand, untilFrame } from './helpers'
 import type { Harness } from './helpers'
+import { tempDir } from './temp'
 
 /**
  * A `<text>` wraps by word unless it is told not to, so anywhere the user's own
@@ -26,7 +26,7 @@ const rowsWith = (t: Harness, needle: string) =>
     .filter(row => row.includes(needle)).length
 
 function repo() {
-  const dir = mkdtempSync(join(tmpdir(), 'druk-long-'))
+  const dir = tempDir('druk-long-')
   const git = (...args: string[]) => execFileSync('git', args, { cwd: dir })
   git('init', '-q', '-b', 'main')
   git('config', 'init.defaultBranch', 'main')
@@ -40,7 +40,7 @@ function repo() {
 
 test('the branch picker gives a long branch and its upstream one row each', async () => {
   const dir = repo()
-  const bare = mkdtempSync(join(tmpdir(), 'druk-long-bare-'))
+  const bare = tempDir('druk-long-bare-')
   execFileSync('git', ['init', '-q', '--bare', bare])
   execFileSync('git', ['remote', 'add', 'origin', bare], { cwd: dir })
   execFileSync('git', ['switch', '-q', '-c', BRANCH], { cwd: dir })

--- a/test/lsp.test.ts
+++ b/test/lsp.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -21,6 +21,7 @@ import type { Diagnostic, RpcMessage } from '../src/lsp/protocol'
 import { headline, isDeprecated, isUnnecessary, severityOf } from '../src/lsp/protocol'
 import { installHint, resolveServer, resolveServers } from '../src/lsp/servers'
 import { createDecoder, encodeMessage } from '../src/lsp/transport'
+import { tempDir } from './temp'
 
 const FAKE = join(import.meta.dir, 'fixtures', 'fake-lsp.ts')
 
@@ -191,7 +192,7 @@ describe('protocol mapping', () => {
 
 describe('installed servers', () => {
   test('a command is rewritten only when druk installed that binary', () => {
-    const root = mkdtempSync(join(tmpdir(), 'druk-lsp-root-'))
+    const root = tempDir('druk-lsp-root-')
     const command = ['pyright-langserver', '--stdio']
     expect(installedCommand(command, root)).toBeNull()
 
@@ -208,7 +209,7 @@ describe('installed servers', () => {
   })
 
   test('a release binary downloads into bin/ and reports HTTP errors', async () => {
-    const root = mkdtempSync(join(tmpdir(), 'druk-lsp-root-'))
+    const root = tempDir('druk-lsp-root-')
     const server = Bun.serve({
       port: 0,
       fetch(req) {
@@ -229,7 +230,7 @@ describe('installed servers', () => {
   }, 20_000)
 
   test('a downloaded server is removed by deleting its binary', async () => {
-    const root = mkdtempSync(join(tmpdir(), 'druk-lsp-root-'))
+    const root = tempDir('druk-lsp-root-')
     const target = join(root, 'bin', 'expert')
     mkdirSync(join(root, 'bin'), { recursive: true })
     writeFileSync(target, '')
@@ -247,14 +248,14 @@ describe('installed servers', () => {
   })
 
   test('a server druk never installed is refused rather than half-removed', async () => {
-    const root = mkdtempSync(join(tmpdir(), 'druk-lsp-root-'))
+    const root = tempDir('druk-lsp-root-')
     expect(await removeServer({ kind: 'manual', command: 'brew install zls' }, 'zls', root)).toBe(
       'druk did not install it',
     )
   })
 
   test('an install creates the manager working directory', async () => {
-    const root = join(mkdtempSync(join(tmpdir(), 'druk-lsp-root-')), 'lsp')
+    const root = join(tempDir('druk-lsp-root-'), 'lsp')
     const path = process.env.PATH
     process.env.PATH = ''
     try {
@@ -268,7 +269,7 @@ describe('installed servers', () => {
   }, 20_000)
 
   test('no node leaves no manager to offer, whatever else is on PATH', () => {
-    const root = mkdtempSync(join(tmpdir(), 'druk-lsp-root-'))
+    const root = tempDir('druk-lsp-root-')
     const path = process.env.PATH
     process.env.PATH = ''
     try {
@@ -281,7 +282,7 @@ describe('installed servers', () => {
   })
 
   test('a prefix keeps the manager that filled it, so the removal matches the install', () => {
-    const root = mkdtempSync(join(tmpdir(), 'druk-lsp-root-'))
+    const root = tempDir('druk-lsp-root-')
     writeFileSync(join(root, '.manager'), 'bun')
     // Both are a given here: bun runs this suite, and node is what the servers
     // the list exists for are run by.
@@ -289,11 +290,11 @@ describe('installed servers', () => {
   })
 
   test('installing a second server keeps the first', async () => {
-    const root = mkdtempSync(join(tmpdir(), 'druk-lsp-root-'))
+    const root = tempDir('druk-lsp-root-')
     // Local directories, so npm resolves them without a registry — the point of
     // the test is what npm does to the tree it finds, not where it got it.
     const fake = (name: string) => {
-      const dir = join(mkdtempSync(join(tmpdir(), 'druk-fake-pkg-')), name)
+      const dir = join(tempDir('druk-fake-pkg-'), name)
       mkdirSync(dir, { recursive: true })
       writeFileSync(
         join(dir, 'package.json'),
@@ -314,7 +315,7 @@ describe('installed servers', () => {
   }, 60_000)
 
   test('a prefix filled before the manifest existed is described, not pruned', async () => {
-    const root = mkdtempSync(join(tmpdir(), 'druk-lsp-root-'))
+    const root = tempDir('druk-lsp-root-')
     const pkg = join(root, 'node_modules', 'typescript-language-server')
     mkdirSync(pkg, { recursive: true })
     writeFileSync(
@@ -337,7 +338,7 @@ describe('installed servers', () => {
   }, 20_000)
 
   test('an install with no npm to run it fails instead of hanging', async () => {
-    const root = mkdtempSync(join(tmpdir(), 'druk-lsp-root-'))
+    const root = tempDir('druk-lsp-root-')
     // PATH is what `spawn` searches, so emptying it is how npm goes missing.
     const path = process.env.PATH
     process.env.PATH = ''
@@ -353,7 +354,7 @@ describe('installed servers', () => {
 
 describe('the project’s own server', () => {
   const project = (files: Record<string, string>) => {
-    const dir = mkdtempSync(join(tmpdir(), 'druk-project-'))
+    const dir = tempDir('druk-project-')
     for (const [name, content] of Object.entries(files)) {
       const path = join(dir, name)
       mkdirSync(join(path, '..'), { recursive: true })
@@ -469,7 +470,7 @@ describe('headline', () => {
 
 describe('client against a live server', () => {
   test('handshake, didOpen diagnostics, didChange clearing them, dispose', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'druk-lsp-'))
+    const dir = tempDir('druk-lsp-')
     const path = join(dir, 'a.ts')
     const deliveries = collector<Diagnostic[]>()
     const client = spawnLspClient({

--- a/test/market.test.ts
+++ b/test/market.test.ts
@@ -1,6 +1,5 @@
 import { expect, test } from 'bun:test'
-import { existsSync, mkdtempSync, readFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import {
@@ -18,6 +17,7 @@ import {
 import type { Fetcher, MarketEntry } from '../src/core/market'
 import { isNewer } from '../src/core/update'
 import { loadExtensions } from '../src/extensions'
+import { tempDir } from './temp'
 
 const REGISTRY = 'https://example.test/extensions/'
 
@@ -54,7 +54,7 @@ const serving = (bodies: Record<string, unknown>, seen: string[] = []): Fetcher 
     )
   }) as Fetcher
 
-const temp = (name: string) => mkdtempSync(join(tmpdir(), `druk-${name}-`))
+const temp = (name: string) => tempDir(`druk-${name}-`)
 
 test('a malformed catalog row is dropped, not fatal', () => {
   const parsed = parseCatalog({

--- a/test/outside-git.test.tsx
+++ b/test/outside-git.test.tsx
@@ -1,14 +1,14 @@
 import { describe, expect, test } from 'bun:test'
 import { execFileSync } from 'node:child_process'
-import { mkdtempSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { watchTree } from '../src/core/fs'
 import { launch, untilFrame, untilGone } from './helpers'
+import { tempDir } from './temp'
 
 function repo() {
-  const dir = mkdtempSync(join(tmpdir(), 'druk-outside-'))
+  const dir = tempDir('druk-outside-')
   const git = (...args: string[]) => execFileSync('git', args, { cwd: dir })
   git('init', '-q', '-b', 'main')
   git('config', 'user.email', 't@e.com')

--- a/test/packages.test.ts
+++ b/test/packages.test.ts
@@ -1,9 +1,7 @@
 import { describe, expect, test } from 'bun:test'
-import { mkdtempSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
 
 import { nfpmConfig, packageFileName } from '../scripts/packages'
+import { tempDir } from './temp'
 
 describe('packageFileName', () => {
   test('deb keeps underscores and Debian arch names', () => {
@@ -40,7 +38,7 @@ describe('nfpmConfig', () => {
 })
 
 test('a missing binary is named before nfpm is ever needed', () => {
-  const empty = mkdtempSync(join(tmpdir(), 'druk-dist-'))
+  const empty = tempDir('druk-dist-')
   const proc = Bun.spawnSync(['bun', 'scripts/packages.ts'], {
     cwd: process.cwd(),
     env: { ...process.env, DRUK_DIST: empty },

--- a/test/pdf.test.ts
+++ b/test/pdf.test.ts
@@ -1,6 +1,5 @@
 import { afterAll, describe, expect, test } from 'bun:test'
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import {
@@ -12,8 +11,9 @@ import {
   stepPdfZoom,
 } from '../src/core/pdf'
 import { pdfFixture } from './pdf-fixture'
+import { tempDir } from './temp'
 
-const dir = mkdtempSync(join(tmpdir(), 'druk-pdf-'))
+const dir = tempDir('druk-pdf-')
 afterAll(() => rmSync(dir, { recursive: true, force: true }))
 
 describe('PDF geometry', () => {

--- a/test/release-notices.test.ts
+++ b/test/release-notices.test.ts
@@ -1,13 +1,14 @@
 import { afterAll, expect, test } from 'bun:test'
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
+
+import { tempDir } from './temp'
 
 const root = join(import.meta.dir, '..')
 // Never the repo's own dist/: a run killed partway through would otherwise leave the
 // binaries a developer just built moved aside, and scripts/test.ts does kill a file
 // that outlasts its cap.
-const dist = mkdtempSync(join(tmpdir(), 'druk-release-'))
+const dist = tempDir('druk-release-')
 afterAll(() => rmSync(dist, { recursive: true, force: true }))
 
 test('release artifacts carry PDFium notices', () => {

--- a/test/review-store.test.ts
+++ b/test/review-store.test.ts
@@ -1,12 +1,12 @@
 import { expect, test } from 'bun:test'
-import { mkdtempSync, readdirSync, readFileSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { loadNotes, readNotes, saveNotes } from '../src/core/review'
 import type { ReviewNote } from '../src/core/review'
+import { tempDir } from './temp'
 
-const notesFile = () => join(mkdtempSync(join(tmpdir(), 'druk-review-store-')), 'review.json')
+const notesFile = () => join(tempDir('druk-review-store-'), 'review.json')
 
 const note = (id: string, over: Partial<ReviewNote> = {}): ReviewNote => ({
   id,

--- a/test/review.test.tsx
+++ b/test/review.test.tsx
@@ -1,6 +1,5 @@
 import { expect, test } from 'bun:test'
-import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { loadNotes, saveNotes } from '../src/core/review'
@@ -19,11 +18,12 @@ import {
   untilGone,
 } from './helpers'
 import type { Harness } from './helpers'
+import { tempDir } from './temp'
 
 // ── Notes, and where they live ─────────────────────────────────────────────
 
 test('notes survive a restart, and clearing forgets the project', () => {
-  const file = join(mkdtempSync(join(tmpdir(), 'druk-notes-')), 'review.json')
+  const file = join(tempDir('druk-notes-'), 'review.json')
   const note = {
     id: 'a',
     path: '/p/src/a.ts',

--- a/test/scale.test.tsx
+++ b/test/scale.test.tsx
@@ -7,18 +7,18 @@
  */
 import { describe, expect, test } from 'bun:test'
 import { execFileSync } from 'node:child_process'
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { mkdirSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { statusMap } from '../src/core/git'
 import { launch, press, settle } from './helpers'
+import { tempDir } from './temp'
 
 /** Past the point where an unwindowed view exhausts the core's renderables. */
 const OVER_THE_CEILING = 6000
 
 function wideDir(count: number) {
-  const dir = mkdtempSync(join(tmpdir(), 'druk-scale-tree-'))
+  const dir = tempDir('druk-scale-tree-')
   mkdirSync(join(dir, 'many'))
   for (let i = 0; i < count; i++) writeFileSync(join(dir, 'many', `f${i}.ts`), 'x\n')
   return dir
@@ -62,7 +62,7 @@ describe('git output size', () => {
     // core/git.ts reads as empty output — the tree would show no marks at all in a
     // repository with a lot of changed files. `statusMap` is the caller with the
     // largest output now that druk runs no diffs of its own.
-    const dir = mkdtempSync(join(tmpdir(), 'druk-scale-status-'))
+    const dir = tempDir('druk-scale-status-')
     execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: dir })
 
     // ~130 bytes of porcelain per entry, so this clears 1 MB comfortably.

--- a/test/search-debounce.test.tsx
+++ b/test/search-debounce.test.tsx
@@ -1,15 +1,15 @@
 import { describe, expect, test } from 'bun:test'
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { mkdirSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { searchProject } from '../src/core/search'
 import { fixture, launch, openFile, press, runCommand, settle } from './helpers'
 import type { Harness } from './helpers'
+import { tempDir } from './temp'
 
 /** A project big enough that one scan is unmistakably slower than one keystroke. */
 function corpus(count: number) {
-  const dir = mkdtempSync(join(tmpdir(), 'druk-corpus-'))
+  const dir = tempDir('druk-corpus-')
   for (let i = 0; i < count; i++) {
     const sub = join(dir, `pkg${i % 40}`)
     mkdirSync(sub, { recursive: true })

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,7 +1,9 @@
 import { afterAll, afterEach } from 'bun:test'
-import { mkdtempSync, rmSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { rmSync } from 'node:fs'
+
+// Static, unlike the imports below: `temp.ts` is `node:fs`/`node:os`/`node:path`
+// and nothing else, so hoisting it above the env assignments captures nothing.
+import { fixtures, tempDir } from './temp'
 
 /**
  * Give every test process its own config home, before anything reads it.
@@ -15,7 +17,7 @@ import { join } from 'node:path'
  * A preload, not a `beforeAll`: the path is captured when the module is first
  * imported, which happens before any hook runs.
  */
-process.env.XDG_CONFIG_HOME = mkdtempSync(join(tmpdir(), 'druk-test-config-'))
+process.env.XDG_CONFIG_HOME = tempDir('druk-test-config-')
 
 /**
  * OSC 9;4 would light the developer's terminal tab for every busy operation the
@@ -29,7 +31,7 @@ process.env.DRUK_PROGRESS = '0'
  * druk installed. Without it a developer who once accepted an install would have
  * `installedCommand` answer for a real binary, and the suite would spawn it.
  */
-process.env.XDG_DATA_HOME = mkdtempSync(join(tmpdir(), 'druk-test-data-'))
+process.env.XDG_DATA_HOME = tempDir('druk-test-data-')
 
 /**
  * And the cache home, where `src/core/market.ts` keeps the extension catalog. A
@@ -37,7 +39,7 @@ process.env.XDG_DATA_HOME = mkdtempSync(join(tmpdir(), 'druk-test-data-'))
  * the market tests would be asserting against whatever the registry published
  * that day.
  */
-process.env.XDG_CACHE_HOME = mkdtempSync(join(tmpdir(), 'druk-test-cache-'))
+process.env.XDG_CACHE_HOME = tempDir('druk-test-cache-')
 
 /**
  * Register the extensions druk ships inside the binary — its languages, and so the
@@ -78,16 +80,17 @@ afterEach(async () => {
 })
 
 /**
- * Delete the fixtures this file made.
+ * Delete the temp directories this file made.
  *
  * A full run creates some three thousand temp projects, and nothing used to
  * remove them: after a few dozen runs the temp folder held ~100k directories,
  * every `mkdtemp` in it slowed down, and whole test files began timing out and
  * being killed — failures that look like flaky tests and are not. `afterAll`
  * rather than `afterEach`, since a file may hand one fixture to several tests.
+ *
+ * Only what `tempDir()` made: a raw `mkdtempSync` is invisible here and leaks.
  */
-afterAll(async () => {
-  const { fixtures } = await import('./helpers')
+afterAll(() => {
   for (const dir of fixtures) rmSync(dir, { recursive: true, force: true })
   fixtures.clear()
 })

--- a/test/sidebar-resize.test.tsx
+++ b/test/sidebar-resize.test.tsx
@@ -1,13 +1,13 @@
 import { describe, expect, test } from 'bun:test'
 import { execFileSync } from 'node:child_process'
-import { mkdtempSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { SIDEBAR_MIN } from '../src/core/config'
 import { ui } from '../src/themes'
 import { fixture, launch, openFile, press, pressEscape, runCommand, settle } from './helpers'
 import type { Harness } from './helpers'
+import { tempDir } from './temp'
 
 const PROJECT = { 'alpha.ts': 'const a = 1\n', 'beta.ts': 'const b = 2\n' }
 
@@ -262,7 +262,7 @@ describe('what must not move when the sidebar does', () => {
   })
 
   test('git marks line up at the panel edge, and follow it on a resize', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'druk-marks-'))
+    const dir = tempDir('druk-marks-')
     const git = (...args: string[]) => execFileSync('git', args, { cwd: dir })
     git('init', '-q', '-b', 'main')
     git('config', 'user.email', 't@e.com')

--- a/test/single-file.test.tsx
+++ b/test/single-file.test.tsx
@@ -1,6 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 
 import { resolveTarget } from '../src/core/cli'
@@ -8,6 +7,7 @@ import type { Config } from '../src/core/config'
 import { loadSession, saveSession } from '../src/core/session'
 import { fixture, launch, press, settle } from './helpers'
 import type { Harness } from './helpers'
+import { tempDir } from './temp'
 
 const PROJECT = {
   'one.ts': 'const one = 1\n',
@@ -123,7 +123,7 @@ describe('the CLI itself', () => {
    * its preload the Solid JSX transform never happens.
    */
   function run(args: string[]) {
-    const home = mkdtempSync(join(tmpdir(), 'druk-home-'))
+    const home = tempDir('druk-home-')
     const proc = Bun.spawnSync(['bun', 'src/index.tsx', ...args], {
       cwd: process.cwd(),
       env: { ...process.env, XDG_CONFIG_HOME: home },

--- a/test/statusbar.test.tsx
+++ b/test/statusbar.test.tsx
@@ -1,15 +1,15 @@
 import { describe, expect, test } from 'bun:test'
 import { execFileSync } from 'node:child_process'
-import { mkdtempSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { fixture, launch, openFile, press, pressEscape, settle } from './helpers'
 import type { Harness } from './helpers'
+import { tempDir } from './temp'
 
 /** A repo with one committed file, one edit and one untracked file. */
 function repo() {
-  const dir = mkdtempSync(join(tmpdir(), 'druk-bar-'))
+  const dir = tempDir('druk-bar-')
   const git = (...args: string[]) => execFileSync('git', args, { cwd: dir })
   git('init', '-q', '-b', 'main')
   git('config', 'user.email', 't@e.com')

--- a/test/symlink.test.tsx
+++ b/test/symlink.test.tsx
@@ -1,14 +1,14 @@
 import { describe, expect, test } from 'bun:test'
-import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { mkdirSync, symlinkSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { flattenVisible, listDir } from '../src/core/fs'
 import { launch, openFile, press } from './helpers'
+import { tempDir } from './temp'
 
 /** A project holding a real directory and file, plus symlinks to each. */
 function linked() {
-  const base = mkdtempSync(join(tmpdir(), 'druk-link-'))
+  const base = tempDir('druk-link-')
   const target = join(base, 'target')
   const project = join(base, 'project')
   mkdirSync(target)

--- a/test/temp.ts
+++ b/test/temp.ts
@@ -1,0 +1,32 @@
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+/**
+ * Every temp directory this process made, deleted when it exits.
+ *
+ * A run of the suite creates some three thousand of these, and nothing used to
+ * remove them: after a few dozen runs the temp folder held ~100k directories and
+ * every `mkdtemp` in it slowed down, until whole test files started timing out
+ * and being killed. `test/setup.ts` empties this in a global `afterAll` — once
+ * per file rather than per test, since a file may hand one directory to several.
+ */
+export const fixtures = new Set<string>()
+
+/**
+ * A temp directory registered for that sweep. Every test that needs one goes
+ * through this rather than calling `mkdtempSync` itself — a raw one leaks for
+ * good, and the git tests, which each build a repository, once left 60k
+ * directories behind and started failing with `ENOENT` on their own files.
+ *
+ * Register the *outermost* directory: a helper that builds a base holding
+ * `origin.git`, `mine` and `theirs` makes one `tempDir` and joins onto it.
+ *
+ * This lives here rather than in `helpers.tsx` so a unit test can have it
+ * without pulling in `<App/>`.
+ */
+export function tempDir(prefix = 'druk-'): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix))
+  fixtures.add(dir)
+  return dir
+}

--- a/test/tree-scroll.test.tsx
+++ b/test/tree-scroll.test.tsx
@@ -1,14 +1,14 @@
 import { describe, expect, test } from 'bun:test'
-import { mkdtempSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { launch, press, pressEscape, settle } from './helpers'
 import type { Harness } from './helpers'
+import { tempDir } from './temp'
 
 /** Enough top-level files that the tree scrolls. */
 function manyFiles(count: number) {
-  const dir = mkdtempSync(join(tmpdir(), 'druk-tree-'))
+  const dir = tempDir('druk-tree-')
   for (let i = 0; i < count; i++) {
     writeFileSync(join(dir, `f${String(i).padStart(3, '0')}.ts`), `const a${i} = ${i}\n`)
   }

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { mkdirSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { buildCommands } from '../src/app/commands'
@@ -11,6 +10,7 @@ import { searchProject, searchText } from '../src/core/search'
 import { isNewer } from '../src/core/update'
 import { THEMES } from '../src/themes'
 import { flattenCommands } from '../src/ui/CommandPalette'
+import { tempDir } from './temp'
 
 describe('search', () => {
   const text = 'const alpha = 1\nlet beta = 2\n// alpha again\n'
@@ -27,7 +27,7 @@ describe('search', () => {
   })
 
   test('walks subdirectories but skips node_modules', () => {
-    const dir = mkdtempSync(join(tmpdir(), 'druk-'))
+    const dir = tempDir()
     mkdirSync(join(dir, 'sub'))
     mkdirSync(join(dir, 'node_modules'))
     writeFileSync(join(dir, 'a.ts'), 'alpha\n')
@@ -41,13 +41,13 @@ describe('search', () => {
 
 describe('files', () => {
   test('refuses binary content', () => {
-    const dir = mkdtempSync(join(tmpdir(), 'druk-'))
+    const dir = tempDir()
     writeFileSync(join(dir, 'bin'), Buffer.from([0x89, 0x50, 0x00, 0x01]))
     expect(() => readFile(join(dir, 'bin'))).toThrow('binary file')
   })
 
   test('an install is reported as a dependency change, and a source edit is not', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'druk-deps-'))
+    const dir = tempDir('druk-deps-')
     const seen: Changed[] = []
     const stop = watchTree(dir, changed => void seen.push(changed))
     try {


### PR DESCRIPTION
Every test helper that builds a git repository made its directory with a raw `mkdtempSync(join(tmpdir(), …))` and never registered it, so `test/setup.ts`'s global `afterAll` — which deletes only what `fixture()` recorded — could not see it.

Those leaked permanently. They reached 61,874 `druk-*` directories in TMPDIR on one machine, at which point `mkdtemp` in that folder slowed down and two tests started failing with `ENOENT` opening their own fixture files:

- `test/git-commands.test.tsx` — "stash reverts the working tree and pop brings it back"
- `test/git-commit-box.test.tsx` — "Commit & sync lands the commit on origin and pulls what it had"

Clearing TMPDIR made the suite pass. AGENTS.md already documented this exact failure mode under "A fixture lives as long as its file"; the git helpers just didn't follow it. The three XDG homes `setup.ts` makes per test process leaked the same way — one config, one data and one cache directory per file per run, 543 of them a run.

## What changed

- **`test/temp.ts`** (new) — owns the swept set and exports `tempDir(prefix = 'druk-')`, which does the mkdtemp and the registration together. Its own module rather than `helpers.tsx` so a unit test can have it without pulling in `<App/>`.
- **`test/helpers.tsx`** — `fixture()` is built on `tempDir()`; the `fixtures` set moved to `temp.ts`.
- **`test/setup.ts`** — sweeps that set, and takes its own three XDG homes from `tempDir` too.
- **39 test files** — every raw `mkdtempSync` converted; imports the rewrite made unused dropped. Helpers that nest (a base holding `origin.git`, `mine` and `theirs`) register the outermost directory, so the children go with it.
- **`test/boundaries.test.ts`** — a new test fails on `mkdtempSync` anywhere in `test/` outside `temp.ts`, so this cannot come back quietly.
- **AGENTS.md** — the harness rules gained the `tempDir` rule beside the fixture-lifetime one.

## Verification

`bun run check` — 180 files pass in 462s, types/lint/format clean. TMPDIR's `druk-*` count is 0 before and after a full run; it was ~800 per run before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)