### PR TITLE
feat(vim): f, t, F, T and the ; , that repeat them

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -46,7 +46,7 @@ Claims re-checked against the tree (not just the previous doc):
 | ARCHITECTURE git still read-only | **True** — lines ~45 and ~319–322 still lie |
 | Tree-only hide undocument | **Mostly false** — ARCHITECTURE is explicit; README table says “file tree” |
 | `file:line:col` | Still true — `resolveTarget` regex accepts col, `Target` has no `col`, `App` calls `requestGoto(line, 0)` |
-| Module sizes | Still exact: EditorPane 1044, vim 642, DiffView 573, SearchPanel 481, workspace 469, SettingsView 272 |
+| Module sizes | Still exact: EditorPane 1044, vim 802, DiffView 573, SearchPanel 481, workspace 469, SettingsView 272 |
 | Project replace / find next / save all | Still absent as product features |
 | Test harness size | ~87 files under `test/` (was “~84+”) |
 | Mutations list | commit, undo, push, fetch, pull, stash, stash pop, diff file/all — matches doc |
@@ -123,7 +123,7 @@ Shipped on `main`. Remaining image work is product polish, not “land the featu
 | File | ~Lines | Suggested split |
 | --- | --- | --- |
 | `ui/EditorPane.tsx` | 1044 | highlight, scrollbar, clipboard gate, vim/typing |
-| `editor/vim.ts` | 642 | motions / operators / text objects |
+| `editor/vim.ts` | 802 | motions / operators / text objects |
 | `ui/DiffView.tsx` | 573 | layout / highlight / nav |
 | `ui/SearchPanel.tsx` | 481 | model / keyboard / render |
 | `app/workspace.ts` | 469 | open-close-save / disk sync / session |
@@ -250,9 +250,12 @@ Effort: **S** &lt;1 day · **M** few days · **L** week+ · **XL** multi-week.
 
 | Priority | Ops |
 | --- | --- |
-| High | `f`/`t`/`F`/`T` `;` `,` · `%` · `*`/`#` · `/` `?` `n` `N` · `.` · `iw`/`aw`/`i"`/`a"` |
+| High | `%` · `*`/`#` · `/` `?` `n` `N` · `.` · `iw`/`aw`/`i"`/`a"` |
 | Medium | Marks, jump list, `Ctrl-d/u`, named registers |
 | Low | Visual block, macros, `:` |
+
+`f`/`t`/`F`/`T` and the `;` `,` that repeat them are shipped — `editor/vim.ts`,
+tests in `test/vim-find.test.tsx`.
 
 ### P4 — Navigation & workspace
 
@@ -352,7 +355,7 @@ Mutations already: commit, undo commit, push, fetch, pull, stash, stash pop, dif
 - Bracket matching  
 - Select all matches  
 - EditorConfig  
-- Vim f/t + search + `.`  
+- Vim search + `.`  
 
 ### v2.0 — Language awareness
 
@@ -410,7 +413,7 @@ Add / extend for:
 6. **Split EditorPane**.  
 7. **Async git / search** for monorepos.  
 8. **Select all matches** + find next/prev.  
-9. **Vim f/t + `/` + `.`**.  
+9. **Vim `/` + `.`**.  
 10. **Homebrew tap** + optional search-ignore policy.
 
 ---

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ instead of breaking startup.
 | `cursorStyle` | `"block"` | `block`, `line` or `underline` — the caret's shape, which vim mode overrides while it is on, since there the shape is what tells normal from insert |
 | `wrap` | `true` | set `false` to keep each line on one row — the tail of a long line is then reached by moving the cursor into it (palette → View → Toggle word wrap) |
 | `scrollPastEnd` | `true` | scroll on past the last line, until it is the only one left on screen — set `false` to stop with it at the bottom (settings → Editor → Scroll past end) |
-| `vim` | `false` | normal / insert / visual modes, `hjkl w b 0 $ gg G`, counts, `i a o`, `x dd dw cw`, `v` + `d y c`, `yy p P`, `u` / `Ctrl+R` |
+| `vim` | `false` | normal / insert / visual modes, `hjkl w b 0 $ gg G`, `f t F T` + `;` `,`, counts, `i a o`, `x dd dw cw`, `v` + `d y c`, `yy p P`, `u` / `Ctrl+R` |
 | `sidebarWidth` | `"auto"` | a quarter of the window, or pin 15–80 columns |
 | `sidebarPosition` | `"left"` | `left` or `right` — which side of the editor the Files / Git / Extensions sidebar sits on (palette → View → Toggle sidebar position) |
 | `trimOnSave` | `false` | on save: strip trailing spaces and end the file with one newline |

--- a/src/editor/vim.ts
+++ b/src/editor/vim.ts
@@ -4,6 +4,9 @@ export type VimMode = 'normal' | 'insert' | 'visual'
 
 type VisualKind = 'char' | 'line'
 
+/** The four character searches: to a character or up against it, either way. */
+type FindKind = 'f' | 'F' | 't' | 'T'
+
 export const MODE_LABELS: Record<VimMode, string> = {
   normal: 'NORMAL',
   insert: 'INSERT',
@@ -23,6 +26,12 @@ export interface VimState {
   pendingTobj: 'i' | 'a' | null // text object prefix (i = inner, a = a/an)
   /** Operator to apply after the text object is resolved; '' in visual mode. */
   textObjOp: '' | 'd' | 'c' | 'y'
+  /** A character search waiting for the character to search for. */
+  pendingFind: FindKind | null
+  /** Operator to apply once that character arrives; '' for a bare motion. */
+  findOp: '' | 'd' | 'c' | 'y'
+  /** What `;` repeats and `,` reverses. */
+  lastFind: { kind: FindKind; char: string } | null
 }
 
 export function initialVimState(): VimState {
@@ -36,6 +45,9 @@ export function initialVimState(): VimState {
     visualKind: 'char',
     pendingTobj: null,
     textObjOp: '',
+    pendingFind: null,
+    findOp: '',
+    lastFind: null,
   }
 }
 
@@ -87,7 +99,12 @@ const MOTION_KEYS = new Set([
   'G',
   '{',
   '}',
+  ';',
+  ',',
 ])
+
+const FIND_KEYS = new Set(['f', 'F', 't', 'T'])
+const OPPOSITE: Record<FindKind, FindKind> = { f: 'F', F: 'f', t: 'T', T: 't' }
 
 /** Motions shared by normal and visual mode. Returns true if `k` was a motion. */
 function motion(editor: Editor, k: string, state: VimState, count: number, counted: boolean) {
@@ -140,6 +157,22 @@ function motion(editor: Editor, k: string, state: VimState, count: number, count
     case '}':
       moveParagraphDown(editor, count)
       return true
+    case ';':
+    case ',': {
+      const last = state.lastFind
+      if (last) {
+        runFind(
+          editor,
+          state,
+          k === ';' ? last.kind : OPPOSITE[last.kind],
+          last.char,
+          count,
+          true,
+          '',
+        )
+      }
+      return true
+    }
     default:
       return false
   }
@@ -193,6 +226,78 @@ function lineStart(text: string, offset: number): number {
 function lineEnd(text: string, offset: number): number {
   const idx = text.indexOf('\n', offset)
   return idx >= 0 ? Math.max(0, idx - 1) : text.length - 1
+}
+
+/**
+ * Where `f`/`t` and their backward pair land, or null when this line does not
+ * hold the character. The search never leaves the line — vim's does not either,
+ * which is what makes `dt)` safe to press without looking.
+ */
+function findTarget(
+  text: string,
+  cursor: number,
+  kind: FindKind,
+  char: string,
+  count: number,
+  repeat: boolean,
+): number | null {
+  const forward = kind === 'f' || kind === 't'
+  const from = lineStart(text, cursor)
+  const to = lineEnd(text, cursor)
+  // `t` leaves the caret resting against its character, so a repeat would find
+  // that same one and never move. Vim steps over it; `;` is for the next one.
+  const skip = repeat && (kind === 't' || kind === 'T') ? 1 : 0
+  let left = count
+  for (let i = forward ? cursor + 1 + skip : cursor - 1 - skip; forward ? i <= to : i >= from;) {
+    if (text[i] === char && --left === 0) {
+      if (kind === 'f' || kind === 'F') return i
+      return kind === 't' ? i - 1 : i + 1
+    }
+    i += forward ? 1 : -1
+  }
+  return null
+}
+
+/**
+ * Move to a character search's landing place, or apply `op` over the ground it
+ * covers. A line without the character is a motion that fails, and a failed
+ * motion takes its operator down with it: `dt,` where there is no comma deletes
+ * nothing rather than falling back to something else.
+ */
+function runFind(
+  editor: Editor,
+  state: VimState,
+  kind: FindKind,
+  char: string,
+  count: number,
+  repeat: boolean,
+  op: '' | 'd' | 'c' | 'y',
+): void {
+  const cursor = editor.cursorOffset
+  const target = findTarget(editor.plainText, cursor, kind, char, count, repeat)
+  if (target === null) return
+  // As every motion here does: a move with a selection live collapses it.
+  if (state.mode === 'visual') editor.clearSelection()
+  if (!op) {
+    editor.cursorOffset = target
+    return
+  }
+  // Forward searches take the character they land on and backward ones leave
+  // the one the cursor is on — which is what makes `df,` eat the comma, `dt,`
+  // stop before it, and `dF,` keep the character being deleted back from.
+  const forward = kind === 'f' || kind === 't'
+  const start = forward ? cursor : target
+  const end = forward ? target : cursor - 1
+  if (end < start) return
+  editor.setSelectionInclusive(start, end)
+  yankSelection(editor, state)
+  if (op === 'y') {
+    editor.clearSelection()
+    editor.cursorOffset = start
+    return
+  }
+  editor.deleteSelection()
+  state.mode = op === 'c' ? 'insert' : 'normal'
 }
 
 function moveParagraphUp(editor: Editor, count: number): void {
@@ -375,6 +480,23 @@ function dispatch(editor: Editor, key: KeyEvent, state: VimState, actions: VimAc
     return false
   }
 
+  // The character a pending f/F/t/T is waiting for, taken before anything below
+  // can read it as something else: `f5` searches for a 5 rather than counting to
+  // one, and `fd` is a search, not the start of a delete.
+  if (state.pendingFind) {
+    const kind = state.pendingFind
+    const op = state.findOp
+    const digits = state.count
+    state.pendingFind = null
+    state.findOp = ''
+    state.count = ''
+    // Escape, an arrow, a chord: nothing that is not a character to look for.
+    if (key.ctrl || k.length !== 1) return true
+    state.lastFind = { kind, char: k }
+    runFind(editor, state, kind, k, Math.max(1, Number.parseInt(digits || '1', 10)), false, op)
+    return true
+  }
+
   if (key.ctrl) {
     if (k === 'r') {
       actions.redo()
@@ -416,6 +538,30 @@ function dispatch(editor: Editor, key: KeyEvent, state: VimState, actions: VimAc
       state.pendingTobj = k
       state.count = digits // the text object target still needs it
       return true
+    }
+
+    // `dt)` and friends: the operator waits for the search, which waits for its
+    // character. `d;` repeats the last search under a new operator.
+    if (op === 'd' || op === 'c' || op === 'y') {
+      if (FIND_KEYS.has(k)) {
+        state.pendingFind = k as FindKind
+        state.findOp = op
+        state.count = digits
+        return true
+      }
+      if ((k === ';' || k === ',') && state.lastFind) {
+        const last = state.lastFind
+        runFind(
+          editor,
+          state,
+          k === ';' ? last.kind : OPPOSITE[last.kind],
+          last.char,
+          count,
+          true,
+          op,
+        )
+        return true
+      }
     }
 
     if (op === 'g') {
@@ -483,6 +629,14 @@ function dispatch(editor: Editor, key: KeyEvent, state: VimState, actions: VimAc
     // bracket key into a text object instead of a motion.
     state.pendingTobj = null
     state.textObjOp = ''
+  }
+
+  // Before the motions and the mode switches, in both modes: the search takes
+  // the next key whatever it is, and `f` is a normal-mode command of its own.
+  if (FIND_KEYS.has(k)) {
+    state.pendingFind = k as FindKind
+    state.count = digits // the character still needs it: `3fx`
+    return true
   }
 
   // Motions run before the mode switches below so visual mode extends the selection.

--- a/src/editor/vim.ts
+++ b/src/editor/vim.ts
@@ -251,7 +251,11 @@ function findTarget(
   for (let i = forward ? cursor + 1 + skip : cursor - 1 - skip; forward ? i <= to : i >= from;) {
     if (text[i] === char && --left === 0) {
       if (kind === 'f' || kind === 'F') return i
-      return kind === 't' ? i - 1 : i + 1
+      const target = kind === 't' ? i - 1 : i + 1
+      // `t` against the character already next to the caret is a motion that
+      // moves nowhere, which vim counts as a failure — so `dt,` with the comma
+      // right there deletes nothing rather than the character under the caret.
+      return target === cursor ? null : target
     }
     i += forward ? 1 : -1
   }
@@ -492,8 +496,12 @@ function dispatch(editor: Editor, key: KeyEvent, state: VimState, actions: VimAc
     state.count = ''
     // Escape, an arrow, a chord: nothing that is not a character to look for.
     if (key.ctrl || k.length !== 1) return true
-    state.lastFind = { kind, char: k }
-    runFind(editor, state, kind, k, Math.max(1, Number.parseInt(digits || '1', 10)), false, op)
+    // The character searched for is *text*, so it is the one the layout printed
+    // and not the key's place on the keyboard: with a Cyrillic layout up `fф`
+    // looks for a `ф`, where `k` is the `a` that key prints on a US board.
+    const char = key.sequence.length === 1 ? key.sequence : key.name
+    state.lastFind = { kind, char }
+    runFind(editor, state, kind, char, Math.max(1, Number.parseInt(digits || '1', 10)), false, op)
     return true
   }
 

--- a/test/vim-find.test.tsx
+++ b/test/vim-find.test.tsx
@@ -130,4 +130,38 @@ describe('vim character search', () => {
     await type(t, '$p')
     expect(await save(t, file)).toBe('const a = fn(one, two);a = fn(one,\nsecond line\n')
   })
+
+  test('dT deletes back to the character, keeping it', async () => {
+    const { t, file } = await vimEditor(LINE)
+    await type(t, '$dT(')
+    expect(await save(t, file)).toBe('const a = fn(;\nsecond line\n')
+  })
+
+  test('a count reaches the repeat', async () => {
+    const { t } = await vimEditor(LINE)
+    await type(t, 'fo2;')
+    expect(at(t)).toBe('Ln 1, Col 21')
+  })
+
+  test('the repeat extends a visual selection', async () => {
+    const { t, file } = await vimEditor(LINE)
+    await type(t, 'vfo;d')
+    expect(await save(t, file)).toBe('ne, two);\nsecond line\n')
+  })
+
+  test('t against the character beside the caret is a motion that failed', async () => {
+    const { t, file } = await vimEditor('a,b\n')
+    // Vim moves nowhere here, and a motion that did not move takes its operator
+    // with it — the caret's own character is not the operator's to eat.
+    await type(t, 'dt,')
+    expect(await save(t, file)).toBe('a,b\n')
+  })
+
+  test('the character searched for is the one the layout printed', async () => {
+    // With a Cyrillic layout up, `ф` sits on the `a` key: a search reading the
+    // key's place rather than its character would land on the `a` at col 5.
+    const { t } = await vimEditor('let a = ф\n')
+    await type(t, 'fф')
+    expect(at(t)).toBe('Ln 1, Col 9')
+  })
 })

--- a/test/vim-find.test.tsx
+++ b/test/vim-find.test.tsx
@@ -1,0 +1,133 @@
+import { describe, expect, test } from 'bun:test'
+
+import { at, save, type, vimEditor } from './vim-harness'
+
+/** Offsets: `(` is 12, the comma 16, `)` 21; the o's are 1, 13 and 20. */
+const LINE = 'const a = fn(one, two);\nsecond line\n'
+
+describe('vim character search', () => {
+  test('f lands on the character, t stops against it', async () => {
+    const { t } = await vimEditor(LINE)
+    await type(t, 'f(')
+    expect(at(t)).toBe('Ln 1, Col 13')
+
+    await type(t, '0t)')
+    expect(at(t)).toBe('Ln 1, Col 21')
+  })
+
+  test('a count picks the nth one', async () => {
+    const { t } = await vimEditor(LINE)
+    await type(t, '2fo')
+    expect(at(t)).toBe('Ln 1, Col 14')
+  })
+
+  test('F and T search back the other way', async () => {
+    const { t } = await vimEditor(LINE)
+    await type(t, '$F(')
+    expect(at(t)).toBe('Ln 1, Col 13')
+
+    await type(t, '$T(')
+    expect(at(t)).toBe('Ln 1, Col 14')
+  })
+
+  test('the search stays on its own line', async () => {
+    const { t } = await vimEditor(LINE)
+    // The only `d` in the file is on line two — vim's search would not reach it.
+    await type(t, 'fd')
+    expect(at(t)).toBe('Ln 1, Col 1')
+  })
+
+  test('a character the line does not hold leaves the cursor alone', async () => {
+    const { t } = await vimEditor(LINE)
+    await type(t, 'fz')
+    expect(at(t)).toBe('Ln 1, Col 1')
+  })
+
+  test('; walks on and , turns back', async () => {
+    const { t } = await vimEditor(LINE)
+    await type(t, 'fo')
+    expect(at(t)).toBe('Ln 1, Col 2')
+    await type(t, ';')
+    expect(at(t)).toBe('Ln 1, Col 14')
+    await type(t, ';')
+    expect(at(t)).toBe('Ln 1, Col 21')
+    await type(t, ',')
+    expect(at(t)).toBe('Ln 1, Col 14')
+  })
+
+  test('; after t steps over the character it is resting against', async () => {
+    const { t } = await vimEditor(LINE)
+    await type(t, 'to')
+    expect(at(t)).toBe('Ln 1, Col 1')
+    // Without the skip this would find the same `o` for ever.
+    await type(t, ';')
+    expect(at(t)).toBe('Ln 1, Col 13')
+  })
+
+  test('; with nothing searched for yet does nothing', async () => {
+    const { t } = await vimEditor(LINE)
+    await type(t, ';')
+    expect(at(t)).toBe('Ln 1, Col 1')
+  })
+
+  test('df takes the character, dt stops before it', async () => {
+    const { t, file } = await vimEditor(LINE)
+    await type(t, 'df,')
+    expect(await save(t, file)).toBe(' two);\nsecond line\n')
+  })
+
+  test('dt leaves the character it stopped against', async () => {
+    const { t, file } = await vimEditor(LINE)
+    await type(t, 'dt,')
+    expect(await save(t, file)).toBe(', two);\nsecond line\n')
+  })
+
+  test('dF deletes back to it, keeping the character under the cursor', async () => {
+    const { t, file } = await vimEditor(LINE)
+    await type(t, '$dF(')
+    expect(await save(t, file)).toBe('const a = fn;\nsecond line\n')
+  })
+
+  test('a search that finds nothing deletes nothing', async () => {
+    const { t, file } = await vimEditor(LINE)
+    await type(t, 'dfz')
+    expect(await save(t, file)).toBe(LINE)
+  })
+
+  test('c through a search opens insert mode where the text was', async () => {
+    const { t, file } = await vimEditor(LINE)
+    await type(t, 'cf(')
+    expect(t.captureCharFrame()).toContain('INSERT')
+    await type(t, 'let b = g')
+    expect(await save(t, file)).toBe('let b = gone, two);\nsecond line\n')
+  })
+
+  test('a count reaches the operator through the search', async () => {
+    const { t, file } = await vimEditor(LINE)
+    await type(t, 'd2fo')
+    expect(await save(t, file)).toBe('ne, two);\nsecond line\n')
+  })
+
+  test('the searched-for character is never read as a command or a count', async () => {
+    const { t, file } = await vimEditor('a1a2a3\n')
+    // `f1` is a search for a 1, not a count of one; `d` after `f` is the target.
+    await type(t, 'f1')
+    expect(at(t)).toBe('Ln 1, Col 2')
+    await type(t, 'x')
+    expect(await save(t, file)).toBe('aa2a3\n')
+  })
+
+  test('the search extends a visual selection', async () => {
+    const { t, file } = await vimEditor(LINE)
+    await type(t, 'vf,d')
+    expect(await save(t, file)).toBe(' two);\nsecond line\n')
+  })
+
+  test('y through a search leaves the cursor where the yank began', async () => {
+    const { t, file } = await vimEditor(LINE)
+    await type(t, 'wyf,')
+    expect(at(t)).toBe('Ln 1, Col 7')
+    await type(t, '$p')
+    expect(await save(t, file)).toBe('const a = fn(one, two);a = fn(one,\nsecond line\n')
+  })
+})


### PR DESCRIPTION
Character search is the motion family vim mode was missing: `hjkl` gets you around a file, but `f` `t` `F` `T` are how you get around a *line*, and `dt)` / `ci"`-shaped edits are most of what the mode is for. `IMPROVEMENTS.md` ranks them High in P3 and #9 overall.

- `f<char>` and `F<char>` land on the character, `t<char>` and `T<char>` stop against it, all four counted (`3fo`).
- `;` repeats the last one and `,` reverses it. A `;` after `t` steps over the character it is already resting against, or it would find that same one for ever.
- The operators take them: `df,` eats the comma, `dt,` stops before it, `dF(` deletes back while keeping the character under the cursor — vim's forward-inclusive, backward-exclusive split. `c` opens insert where the text was, `y` leaves the cursor where the yank began, and `d;` repeats a search under a new operator.
- The search stays on its line, as vim's does, and a line that does not hold the character is a motion that fails — which carries its operator down with it, so `dt,` with no comma deletes nothing rather than falling back to something else.

Two things worth pointing at in the diff. The pending character is read before the count and the operator table, or `f5` would count to one and `fd` would start a delete — it is a literal, and nothing else may look at it first. And `pendingFind` / `findOp` mirror the `pendingTobj` / `textObjOp` pair already there rather than inventing a second shape for "an operator waiting for its target".

Tests: a file of 17 covering each motion, counts, both operator edge cases per direction, the `t` repeat skip, the line boundary, the not-found path (cursor still, buffer untouched), visual-mode extension, and the literal-character case.

`bun run check` is green except `test/boundaries.test.ts`, which fails the same way on a clean `main` — `test/changes-view.test.tsx` uses `mkdtempSync` directly, which #92's new rule forbids. Untouched here; happy to send that one separately if you want it.
