### PR TITLE
feat(vim): Center the cursor line with zz

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ instead of breaking startup.
 | `cursorStyle` | `"block"` | `block`, `line` or `underline` — the caret's shape, which vim mode overrides while it is on, since there the shape is what tells normal from insert |
 | `wrap` | `true` | set `false` to keep each line on one row — the tail of a long line is then reached by moving the cursor into it (palette → View → Toggle word wrap) |
 | `scrollPastEnd` | `true` | scroll on past the last line, until it is the only one left on screen — set `false` to stop with it at the bottom (settings → Editor → Scroll past end) |
-| `vim` | `false` | normal / insert / visual modes, `hjkl w b 0 $ gg G`, `f t F T` + `;` `,`, counts, `i a o`, `x dd dw cw`, `v` + `d y c`, `yy p P`, `u` / `Ctrl+R` |
+| `vim` | `false` | normal / insert / visual modes, `hjkl w b 0 $ gg G`, `f t F T` + `;` `,`, `zz`, counts, `i a o`, `x dd dw cw`, `v` + `d y c`, `yy p P`, `u` / `Ctrl+R` |
 | `sidebarWidth` | `"auto"` | a quarter of the window, or pin 15–80 columns |
 | `sidebarPosition` | `"left"` | `left` or `right` — which side of the editor the Files / Git / Extensions sidebar sits on (palette → View → Toggle sidebar position) |
 | `trimOnSave` | `false` | on save: strip trailing spaces and end the file with one newline |

--- a/src/editor/vim.ts
+++ b/src/editor/vim.ts
@@ -57,10 +57,14 @@ export function initialVimState(): VimState {
  * Undo and redo belong to the editor pane, not the buffer: it keeps a history of
  * whole typing bursts and replaces the text wholesale, which resets the buffer's
  * own. Calling `editor.undo()` here would step a history that is always empty.
+ *
+ * Centering (`zz`) is the same split: wrapping, the scroll-past-end clamp and
+ * the visual-row map all live on the pane, and `scrollY` is read-only.
  */
 export interface VimActions {
   undo: () => void
   redo: () => void
+  centerLine: () => void
 }
 
 type Editor = TextareaRenderable
@@ -586,6 +590,15 @@ function dispatch(editor: Editor, key: KeyEvent, state: VimState, actions: VimAc
       }
       return true
     }
+    if (op === 'z') {
+      // `zz` redraws with the caret's line in the middle; a count is that line,
+      // the way `5G` is — vim's `[count]zz`.
+      if (k === 'z') {
+        if (digits) editor.gotoLine(count - 1)
+        actions.centerLine()
+      }
+      return true
+    }
     if (k === op) {
       // dd / yy / cc — linewise
       if (op === 'd') deleteLine(editor, state, count)
@@ -656,6 +669,14 @@ function dispatch(editor: Editor, key: KeyEvent, state: VimState, actions: VimAc
   // Motions run before the mode switches below so visual mode extends the selection.
   if (motion(editor, k, state, count, digits !== '')) {
     if (state.mode === 'visual') markVisual(editor, state)
+    return true
+  }
+
+  // Ahead of the visual/normal split so `zz` still recentres while a selection
+  // is live — it is a viewport command, not an operator on the text.
+  if (k === 'z') {
+    state.pending = 'z'
+    state.count = digits
     return true
   }
 

--- a/src/ui/EditorPane.tsx
+++ b/src/ui/EditorPane.tsx
@@ -2443,7 +2443,16 @@ export function EditorPane(props: EditorPaneProps) {
     if (folded() && vimState.mode !== 'insert' && VIM_EDITS.has(command)) {
       releaseFoldForEdit()
     }
-    const stepped = { undo: () => stepHistory('undo'), redo: () => stepHistory('redo') }
+    const stepped = {
+      undo: () => stepHistory('undo'),
+      redo: () => stepHistory('redo'),
+      centerLine: () => {
+        if (!editor) return
+        const row = rowAtLine(editor.logicalCursor.row)
+        const height = editor.height || editor.editorView.getViewport().height
+        if (height > 0) scrollToRow(row - Math.floor(height / 2))
+      },
+    }
     if (handleVimKey(editor, key, vimState, stepped)) key.preventDefault()
     if (vimState.mode !== before) {
       setVimMode(vimState.mode)

--- a/test/vim.test.tsx
+++ b/test/vim.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test'
 import { readFileSync } from 'node:fs'
 
 import { press, pressEscape, settle } from './helpers'
+import type { Harness } from './helpers'
 import { at, save, type, vimEditor } from './vim-harness'
 
 describe('vim mode basics', () => {
@@ -25,7 +26,7 @@ describe('vim mode basics', () => {
 
   test('normal mode swallows unknown keys instead of typing them', async () => {
     const { t, file } = await vimEditor()
-    await press(t, i => void i.typeText('zzz')) // no such command — must not reach the buffer
+    await press(t, i => void i.typeText('qqq')) // no such command — must not reach the buffer
     await press(t, i => i.pressKey('i'))
     await press(t, i => void i.typeText('X'))
     await press(t, i => i.pressKey('s', { ctrl: true }))
@@ -246,5 +247,41 @@ describe('normal-mode edits', () => {
     await press(t, i => i.pressKey('r', { ctrl: true }))
     await settle(t)
     expect(await save(t, file)).toBe('two\nthree\n')
+  })
+})
+
+describe('viewport', () => {
+  const long = `${Array.from({ length: 200 }, (_, i) => `line ${i}`).join('\n')}\n`
+  const shown = (t: Harness) =>
+    t
+      .captureCharFrame()
+      .split('\n')
+      .flatMap(row => row.match(/line \d+/) ?? [])
+
+  test('zz puts the cursor line in the middle of the window', async () => {
+    const { t } = await vimEditor(long)
+    await type(t, '100G')
+    expect(at(t)).toBe('Ln 100, Col 1')
+    const before = shown(t)
+    expect(before).toContain('line 99')
+    // G reveals the line by the smallest scroll, so it sits near the bottom.
+    expect(before[0]).not.toBe('line 90')
+
+    await type(t, 'zz')
+    expect(at(t)).toBe('Ln 100, Col 1')
+    const after = shown(t)
+    expect(after[0]).toBe('line 90')
+    const mid = after.indexOf('line 99')
+    expect(Math.abs(mid - Math.floor(after.length / 2))).toBeLessThanOrEqual(1)
+    expect(t.captureCharFrame()).not.toContain('●')
+  })
+
+  test('a count with zz jumps to that line and centres it', async () => {
+    const { t } = await vimEditor(long)
+    await type(t, '50zz')
+    expect(at(t)).toBe('Ln 50, Col 1')
+    const lines = shown(t)
+    expect(lines[0]).toBe('line 40')
+    expect(lines).toContain('line 49')
   })
 })

--- a/test/vim.test.tsx
+++ b/test/vim.test.tsx
@@ -284,4 +284,24 @@ describe('viewport', () => {
     expect(lines[0]).toBe('line 40')
     expect(lines).toContain('line 49')
   })
+
+  test('zz recentres with a selection live, and the selection survives', async () => {
+    const { t, file } = await vimEditor(long)
+    await type(t, '100G')
+    await type(t, 'vjj')
+    await type(t, 'zz')
+    expect(shown(t)[0]).toBe('line 92') // the caret is on line 102 after vjj
+    // The viewport moved; the selection is still the one `v` started.
+    await type(t, 'd')
+    expect(await save(t, file)).toContain('line 98\nine 101\n')
+  })
+
+  test('zz near the top of the file scrolls nothing and moves no caret', async () => {
+    const { t } = await vimEditor(long)
+    await type(t, 'gg')
+    const before = shown(t)
+    await type(t, 'zz')
+    expect(at(t)).toBe('Ln 1, Col 1')
+    expect(shown(t)).toEqual(before)
+  })
 })


### PR DESCRIPTION
## Summary
- Add vim's `zz` in normal and visual mode: redraw so the caret's line sits in the middle of the window, without moving the caret or dirtying the buffer.
- A count is that line (`50zz`), matching `5G`.
- Scroll goes through the editor pane so wrapping and `scrollPastEnd` stay consistent.

## Test plan
- [x] `bun test test/vim.test.tsx`
- [ ] Enable vim, open a long file, `100G` then `zz` — the line stays put and moves to the middle of the screen
- [ ] `50zz` jumps to line 50 and centres it
- [ ] Insert mode still types `zz`; Esc then `zz` centres